### PR TITLE
fix: adds unspecified return type for `addContact`

### DIFF
--- a/chat/client-api.md
+++ b/chat/client-api.md
@@ -55,7 +55,7 @@ abstract class Client {
   public abstract addContact(params: {
     account: string;
     publicKey: string;
-  })
+  }): Promise<void>
 
   // returns all invites matching an account / returns maps of invites indexed by id
   public abstract getInvites(params: {


### PR DESCRIPTION
- Fixing unspecified return type for `addContact` method
- This may well be a synchronous call in the end if this is client-side only, but keeping the `Promise<void>` return type for consistency for now.