### PR TITLE
fix: `chat_message` event payload type

### DIFF
--- a/chat/client-api.md
+++ b/chat/client-api.md
@@ -81,7 +81,7 @@ abstract class Client {
   public abstract on("chat_joined",  ({ topic: string }) => {}): void;
 
   // subscribe to new chat messages received
-  public abstract on("chat_message", ({ topic: string, message: string }) => {}): void;
+  public abstract on("chat_message", ({ topic: string, payload: Message }) => {}): void;
 
   // subscribe to new chat thread left
   public abstract on("chat_left",  ({ topic: string }) => {}): void;

--- a/chat/rpc-methods.md
+++ b/chat/rpc-methods.md
@@ -52,7 +52,9 @@ Used to send a message to its peer through topic T.
 ```jsonc
 // wc_chatMessage params
 {
-  "message": string,
+  "message" : string,
+  "authorAccount": string,
+  "timestamp": Int64, 
   "media": Media // optional
 }
 ```


### PR DESCRIPTION
- Aligns `chat_message` payload with the defined `Message` data type, i.e. incoming argument should be `Message` not a plain `string`
- Renames argument key from `message` to `payload` to avoid the syntactically awkward `message.message`