### PR TITLE
Iridium params for Sign and Chat

### DIFF
--- a/chat/rpc-methods.md
+++ b/chat/rpc-methods.md
@@ -25,6 +25,8 @@ Used to invite a peer through topic I. Requires a success response with associat
 - Success response is equivalent to invite acceptance.
 - Error response is equivalent to invite rejection.
 
+**Request**
+
 ```jsonc
 // wc_chatInvite params
 {
@@ -33,13 +35,28 @@ Used to invite a peer through topic I. Requires a success response with associat
   "publicKey": string,
   "signature": string, // optional
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | true     |
+| Tag     | 2000     |
+
 ```
+
+**Response**
 
 ```jsonc
 // Success result
 {
   "publicKey": string, // invitee public key
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 2001     |
 ```
 
 ### wc_chatMessage
@@ -49,6 +66,8 @@ Used to send a message to its peer through topic T.
 - Success response is equivalent to message delivery receipt.
 - Error response is equivalent to message delivery failure.
 
+**Request**
+
 ```jsonc
 // wc_chatMessage params
 {
@@ -57,40 +76,93 @@ Used to send a message to its peer through topic T.
   "timestamp": Int64,
   "media": Media // optional
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | true     |
+| Tag     | 2002     |
 ```
+
+**Response**
 
 ```jsonc
 // Success result
 {
   // empty
 }
-```
 
-### wc_chatPing
-
-Used to evaluate if peer is currently online. Timeout at 30 seconds
-
-```jsonc
-// wc_chatPing params
-{
-  // empty
-}
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 2003     |
 ```
 
 ### wc_chatLeave
 
 Used to signal to a peer that a chat thread is being left.
 
+**Request**
+
 ```jsonc
-// wc_chatLeave params
+// wc_chatPing params
 {
   // empty
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 2004     |
 ```
+
+**Response**
 
 ```jsonc
 // Success result
 {
   // empty
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 2005     |
+```
+
+### wc_chatPing
+
+Used to evaluate if peer is currently online. Timeout at 30 seconds
+
+**Request**
+
+```jsonc
+// wc_chatPing params
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 30       |
+| Prompt  | false    |
+| Tag     | 2006     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 30       |
+| Prompt  | false    |
+| Tag     | 2007     |
 ```

--- a/relay/relay-server.md
+++ b/relay/relay-server.md
@@ -10,9 +10,9 @@ The following definitions are shared concepts across all JSON-RPC methods for th
 
 - **topic** - a target topic for the message to be subscribed by the receiver.
 - **message** - a plaintext message to be relayed to any subscribers on the topic.
-- **ttl** - a storage duration for the message to be cached server-side in **seconds** (aka time-to-live). **(0 - no caching, -1 - forever)**
-- **tag** - a label that identifies which api sent a message. It allows collecting metrics. **(0 - unknown, 1 - sign, 2 - chat, 3 - auth, 4 - push)**
-- **prompt** - a flag that identifies whether the server should trigger a notification webhook to a client through a push server **(true/false)**
+- **ttl** - a storage duration for the message to be cached server-side in **seconds** (aka time-to-live).
+- **tag** - a label that identifies what type of message is sent based on the rpc method used.
+- **prompt** - a flag that identifies whether the server should trigger a notification webhook to a client through a push server.
 - **id** - a unique identifier for each subscription targetting a topic.
 
 ## Publish payload

--- a/sign/rpc-methods.md
+++ b/sign/rpc-methods.md
@@ -18,7 +18,78 @@ error: {
 }
 ```
 
-## Pairings:
+## Pairing:
+
+### wc_pairingDelete
+
+Used to inform the peer to close and delete a pairing. All associated sessions of the given pairing must also be deleted.
+
+**Request**
+
+```jsonc
+// wc_pairingDelete params
+{
+  "code": Int64,
+  "message": string
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 1000     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 1001     |
+```
+
+### wc_pairingPing
+
+Used to evaluate if peer is currently online. Timeout at 30 seconds
+
+**Request**
+
+```jsonc
+// wc_pairingPing params
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 30       |
+| Prompt  | true     |
+| Tag     | 1102     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 30       |
+| Prompt  | false    |
+| Tag     | 1103     |
+```
+
+## Session:
 
 ### wc_sessionPropose
 
@@ -28,6 +99,8 @@ Used to propose a session through topic A. Requires a success response with asso
 - Error response is equivalent to session rejection.
 - This method _might_ require a special timeout, because it needs end-user interaction to respond.
 - Proposer must use the relay parameter selected and sent by the responder, if different than the proposed one.
+
+**Request**
 
 ```jsonc
 // wc_sessionPropose params
@@ -62,7 +135,15 @@ Used to propose a session through topic A. Requires a success response with asso
     }
   },
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Prompt  | true     |
+| Tag     | 1100     |
 ```
+
+**Response**
 
 ```jsonc
 // Success result
@@ -73,34 +154,19 @@ Used to propose a session through topic A. Requires a success response with asso
   },
   "responderPublicKey": string,
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Prompt  | false    |
+| Tag     | 1101     |
 ```
-
-### wc_pairingDelete
-
-Used to inform the peer to close and delete a pairing. All associated sessions of the given pairing must also be deleted.
-
-```jsonc
-// wc_pairingDelete params
-{
-  "code": Int64,
-  "message": string
-}
-```
-
-### wc_pairingPing
-
-```jsonc
-// wc_pairingPing params
-{
-  // empty
-}
-```
-
-## Sessions:
 
 ### wc_sessionSettle
 
 Used to settle a session over topic B.
+
+**Request**
 
 ```jsonc
 // wc_sessionSettle params
@@ -134,9 +200,34 @@ Used to settle a session over topic B.
   },
   "expiry": Int64, // seconds
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Prompt  | false    |
+| Tag     | 1102     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Prompt  | false    |
+| Tag     | 1103     |
 ```
 
 ### wc_sessionUpdate
+
+Used to update the namespaces of a session.
+
+**Request**
 
 ```jsonc
 // wc_sessionUpdate params
@@ -156,6 +247,27 @@ Used to settle a session over topic B.
     }
   }
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 1104     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 1105     |
 ```
 
 ### wc_sessionExtend
@@ -164,37 +276,41 @@ Used to extend the lifetime of a session.
 
 - The expiry is the absolute timestamp of the expiration date, in seconds.
 
+**Request**
+
 ```jsonc
 // wc_sessionExtend params
 {
   "expiry": number
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 1106     |
 ```
 
-### wc_sessionDelete
-
-Used to inform the peer to close and delete a session. The reason field should be a human-readable message defined by the SDK consumer to be shown on the peer's side.
+**Response**
 
 ```jsonc
-// wc_sessionDelete params
-{
-  "code": Int64,
-  "message": string
-}
-```
-
-### wc_sessionPing
-
-```jsonc
-// wc_sessionPing params
+// Success result
 {
   // empty
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 1107     |
 ```
 
 ### wc_sessionRequest
 
 Sends a CAIP-27 request to the peer client. The client should immediately reject the request and respond an error if the target session permissions doesn't include the requested method or chain ID.
+
+**Request**
 
 ```jsonc
 // wc_sessionRequest params
@@ -205,9 +321,32 @@ Sends a CAIP-27 request to the peer client. The client should immediately reject
   },
   "chainId": string
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Prompt  | true     |
+| Tag     | 1108     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Prompt  | false    |
+| Tag     | 1109     |
 ```
 
 ### wc_sessionEvent
+
+**Request**
 
 ```jsonc
 // wc_sessionEvent params
@@ -218,4 +357,94 @@ Sends a CAIP-27 request to the peer client. The client should immediately reject
   },
   "chainId": string
 }
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Prompt  | true     |
+| Tag     | 1110     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Prompt  | false    |
+| Tag     | 1111     |
+```
+
+### wc_sessionDelete
+
+Used to inform the peer to close and delete a session. The reason field should be a human-readable message defined by the SDK consumer to be shown on the peer's side.
+
+**Request**
+
+```jsonc
+// wc_sessionDelete params
+{
+  "code": Int64,
+  "message": string
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 1112     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 1113     |
+```
+
+### wc_sessionPing
+
+Used to evaluate if peer is currently online. Timeout at 30 seconds
+
+**Request**
+
+```jsonc
+// wc_sessionPing params
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 30       |
+| Prompt  | false    |
+| Tag     | 1114     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+{
+  // empty
+}
+
+| Iridium |          |
+| ------- | -------- |
+| TTL     | 30       |
+| Prompt  | false    |
+| Tag     | 1115     |
 ```


### PR DESCRIPTION
**NOTE:** This one is quite the PR that needs to be reviewed carefully.

Summary:
Introduction of granular tags and also specifying prompt and ttl for each RPC method.

Changes:
- Remove old tags for each API (0 = unknown,1 = Sign, 2 = Chat, 3 = Auth, 4 = Push) 
- Add wider range of tags per each RPC method (1xxx = Sign, 2xxx = Chat)
- Remove special cases for Publish TTL (-1 = indefinite, 0 = no caching)
- Add TTL values for each RPC method (30 = 30 secs, 300 = 5mins, 86400 = 24 hours)
- Add prompt flag for each RPC method (only for requests, never responses)

Some patterns that I believe we should follow for consistency when defining RPC methods:
- Request and Response SHOULD always match the same TTL
- Request CAN use Prompt flag but Response SHOULD be false
- Ping methods MUST use TTL of 30 secs
- Sign methods requiring user-action MUST use TTL of 5mins 
- Chat methods MUST use TTL of 24 hours
- Response tag SHOULD always be an increment of 1 matching Request tag
- Response success result SHOULD be empty params (instead of boolean)

Regarding TTL:
For the time being TTL has been set to be only up to 24 hours, given discussions with the Cloud team about expanding the infrastructure to support higher TTLs. In the future we might increase TTL of some methods especially for Chat API.

Issue:
Fix #84 