### PR TITLE
Update data-structures.md

### DIFF
--- a/auth/data-structures.md
+++ b/auth/data-structures.md
@@ -38,7 +38,7 @@ interface RequestParams {
 
 ```typescript
 interface RespondParams {
-  topic: string;
+  id: number;
   signature: CacaoSignature;
 }
 ```


### PR DESCRIPTION
`auth_request` event provides formatted eip-4361 message and request id, so I think it is more convenient and makes more sense that `respondParams` contains associated request id in it's body.