### PR TITLE
Update data-structures.md

### DIFF
--- a/auth/data-structures.md
+++ b/auth/data-structures.md
@@ -21,7 +21,6 @@ Metadata is a set of parameters used to identify each participant in a session a
 
 ```typescript
 interface RequestParams {
-  chainId: string;
   domain: string;
   nonce: string;
   aud: string;


### PR DESCRIPTION
in caip-74 specs chainID is derived from issuer's caip-10:
`Chain ID: {.p.iss[chainId]}`
so maybe it make sense that chain id is set on issuer's side when responding?