### PR TITLE
feat: notify specs

### DIFF
--- a/docs/specs/clients/notify/README.md
+++ b/docs/specs/clients/notify/README.md
@@ -1,0 +1,5 @@
+# Notify API Overview
+
+## Description
+
+Notify API allows wallet users to register subscriptions for different blockchain, application or off-chain events that are relevant to the user and can be notified from their wallet.

--- a/docs/specs/clients/notify/client-api.md
+++ b/docs/specs/clients/notify/client-api.md
@@ -1,0 +1,69 @@
+# Client API
+
+:::caution
+
+Notify API is under development. Want early access? Join our [Pilot Program](https://walletconnect.com/partners)
+
+:::
+
+```typescript
+abstract class Client {
+  // ---------- Methods ----------------------------------------------- //
+
+  // initializes the client with persisted storage and a network connection
+  public abstract init(): Promise<void>;
+  
+  // send notify subscription
+  public abstract subscribe(params: { 
+        metadata: Metadata,
+        account: string,
+        scope: string[],
+        onSign: (message: string) => Cacao.Signature
+  }): Promise<boolean>;
+
+  // update notify subscription
+  public abstract update(params: { topic: string, scope: string[] }): Promise<boolean>;
+
+  // query notification types available for a dapp domain
+  public abstract getNotificationTypes(params: {
+      domain: string,
+  }): Promise<NotifyAvailableTypes>
+
+  // query all active subscriptions
+  public abstract getActiveSubscriptions(params: {
+    account?: string
+  }): Promise<Record<string, NotifySubscription>>;
+
+  // get all messages for a subscription
+  public abstract getMessageHistory(params: { topic: string }): Promise<Record<number, NotifyMessageRecord>>
+
+  // delete active subscription
+  public abstract deleteSubscription(params: { topic: string }): Promise<void>;
+  
+  // delete notify message
+  public abstract deleteNotifyMessage(params: { id: number }): Promise<void>;
+  
+  // decrypt notify subscription message
+  public abstract decryptMessage(topic: string, encryptedMessage: string): Promise<NotifyMessage>;
+  
+  // Enable Sync by registering sync keys
+  public abstract enableSync({
+        account: string, 
+        onSign: (message: string) => Cacao.Signature
+  }): Promise<void>;
+
+  // ---------- Events ----------------------------------------------- //
+
+  // for wallet to listen for notify subscription created
+  public abstract on("notify_subscription", (result: NotifySubscription | Error) => {}): void;
+  
+  //  for wallet to listen on notify messages
+  public abstract on("notify_message", (message: NotifyMessageRecord, metadata: Metadata) => {}): void;
+  
+  // for wallet to listen for result of notify subscription update
+  public abstract on("notify_update", (result: NotifySubscription | Error) => {}): void;
+
+  // for wallet to listen on notify deletion
+  public abstract on("notify_delete", (topic: string) => {}): void;
+}
+```

--- a/docs/specs/clients/notify/dapp-authentication.md
+++ b/docs/specs/clients/notify/dapp-authentication.md
@@ -1,0 +1,52 @@
+# Dapp Authentication
+
+Notify API requires Dapp developers to host a did:web document to expose public keys for two specific purposes:
+
+    * key agreement - public key used to subscribe to the chosen notify server
+    * authentication - public key used to sign message published by the chosen notify server
+
+This should be available as a `did.json` document under the `.well-known` path for the Dapp Domain specified as did:web identifier.
+
+Here is an example for the two public keys being exposed:
+
+```jsonc
+did:web:example.com -> https://example.com/.well-known/did.json
+
+// did.json
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "id": "did:web:example.com",
+  "verificationMethod": [
+    {
+      "id": "did:web:example.com#key-0",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:example.com",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "X25519",
+        "x": "9GXjPGGvmRq9F6Ng5dQQ_s31mfhxrcNZxRGONrmH30k"
+      }
+    },
+    {
+      "id": "did:web:example.com#key-1",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:example.com",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "0-e2i2_Ua1S5HbTYnVB0lj2Z2ytXu2-tYmDFf8f5NjU"
+      }
+    },
+
+  ],
+  "keyAgreement": [
+    "did:web:example.com#key-0"
+  ],
+  "authentication": [
+    "did:web:example.com#key-1"
+  ],
+}
+```

--- a/docs/specs/clients/notify/dapp-authentication.md
+++ b/docs/specs/clients/notify/dapp-authentication.md
@@ -2,8 +2,8 @@
 
 Notify API requires Dapp developers to host a did:web document to expose public keys for two specific purposes:
 
-    * key agreement - public key used to subscribe to the chosen notify server
-    * authentication - public key used to sign message published by the chosen notify server
+- key agreement - public key used to subscribe to the chosen notify server
+- authentication - public key used to sign message published by the chosen notify server
 
 This should be available as a `did.json` document under the `.well-known` path for the Dapp Domain specified as did:web identifier.
 

--- a/docs/specs/clients/notify/data-structures.md
+++ b/docs/specs/clients/notify/data-structures.md
@@ -1,0 +1,59 @@
+# Data Structures
+
+## Notify Subscription
+
+```jsonc
+{
+  "topic": string,
+  "account": string,
+  "relay": {
+    "protocol": string,
+    "data": string
+  },  
+  "metadata": Metadata,
+  "scope": Record<string, {description: string, enabled: boolean}>,
+  "expiry": number,
+}
+```
+
+## Notify Message
+
+```jsonc
+{
+  "title": string,
+  "body": string,
+  "icon": string,
+  "url": string,
+  "type": string
+}
+```
+
+## Notify Message Record
+
+```jsonc
+{
+  "id": string,
+  "topic": string,
+  "publishedAt": Int64,
+  "message": NotifyMessage
+}
+```
+
+## Notify Type
+
+```jsonc
+{
+  "name": string,
+  "description": string
+}
+```
+
+## Notify Available Types
+
+```jsonc
+{
+  "version": number,
+  "lastModified": Int64,
+  "types": NotifyType[]
+}
+```

--- a/docs/specs/clients/notify/error-codes.md
+++ b/docs/specs/clients/notify/error-codes.md
@@ -1,0 +1,27 @@
+# Error Codes
+
+## INVALID
+
+```sh
+case .invalidProposal: return 1000
+```
+
+## REJECTED
+
+```sh
+case .userRejected return 5000
+```
+
+## REASON
+
+```sh
+case .userUnsubscribed return 6000
+case .userHasExistingSubscription return 6001
+```
+
+## FAILURE
+
+```sh
+case .approvalFailed: return 7002
+case .rejectionFailed: return 7003
+```

--- a/docs/specs/clients/notify/notify-authentication.md
+++ b/docs/specs/clients/notify/notify-authentication.md
@@ -1,0 +1,126 @@
+# Notify Authentication
+
+In this document we will describe the authentication payloads for different methods:
+
+- Notify Subscription
+- Notify Subscription Response
+- Notify Message
+- Notify Receipt
+- Notify Update Response
+
+
+All of the above authentication payloads will share the following claims:
+
+- act - description of action intent. Must be equal to specific value defined in each payload
+- iat - timestamp when jwt was issued
+- exp - timestamp when jwt must expire
+- ksu - key server for identity key verification
+
+## Notify Subscription
+
+The wallet creates a notify subscription by signing a JWT with the Identity Key corrresponding the blockchain account subscribed
+
+This is achieved using [Identity Keys](../../servers/keys/identity-keys) and did-jwt with the following claims:
+
+- act - description of action intent. Must be equal to "notify_subscription"
+- iss - did:key of an identity key. Enables to resolve attached blockchain account.
+- aud - did:key of an identity key. Enables to resolve associated Dapp domain used.
+- sub - blockchain account that this notify subscription is associated with (did:pkh)
+- scp - scope of notification types authorized by the user
+- app - dapp's domain url
+
+Expiry should be calculated from the addition of the issuance date and the notify request TTL (2592000 seconds)
+
+## Notify Subscription Response
+
+Once the Notify Server has successfully handled the incoming notify subscription request, it will acknowledge it by responding with a public key used for key agreement on the Notify topic.
+
+- act - description of action intent. Must be equal to "notify_subscription_response"
+- iss - did:key of an identity key. Allows for the resolution of which Notify server was used.
+- aud - did:key of an identity key. Allows for the resolution of the attached blockchain account.
+- sub - did:key of the public key used for key agreement on the Notify topic 
+- app - dapp's domain url
+
+Expiry should be calculated from the addition of the issuance date and the notify request TTL (86400 seconds)
+
+## Notify Message
+
+For each Notify message sent, the Dapp will have an authenticated payload signed by the chosen Notify Server which will have associated an authentication key for each Dapp domain.
+
+This is achieved using [Dapp Authentication](./dapp-authentication.md) keys which are exposed by the Notify Server but hosted on the Dapp's domain.
+
+The message payload is a did-jwt with the following claims:
+
+- act - description of action intent. Must be equal to "notify_message"
+- iss - did:key of an identity key. Enables to resolve associated Dapp domain used.
+- aud - blockchain account that notify subscription is associated with (did:pkh)
+- sub - hash of the matching subscription payload
+- app - dapp's domain url
+- msg - message object including the following parameters:
+    - title - short message used in the title of the notification
+    - body - long messages ued in the body of the notification
+    - icon - image url used to display with the notification
+    - url -  redirect url for call-to-action related to notification
+    - type - notification type which matches the scope of notify subscription
+
+Expiry should be calculated from the addition of the issuance date and the notify request TTL (86400 seconds)
+
+## Notify Receipt
+
+For each Notify message received, the Wallet will acknowledge its receipt with an authenticated payload that verifies that an authorized identity key received it.
+
+- act - description of action intent. Must be equal to "notify_receipt"
+- iss - did:key of an identity key. Enables to resolve attached blockchain account.
+- aud - did:key of an identity key. Enables to resolve associated Dapp domain used.
+- sub - hash of the stringified notify message object received
+- app - dapp's domain url
+
+Expiry should be calculated from the addition of the issuance date and the notify request TTL (86400 seconds)
+
+## Notify Update
+
+The wallet creates a notify update by signing a JWT with the Identity Key corrresponding the blockchain account subscribed
+
+This is achieved using [Identity Keys](../../servers/keys/identity-keys) and did-jwt with the following claims:
+
+- act - description of action intent. Must be equal to "notify_update"
+- iss - did:key of an identity key. Enables to resolve attached blockchain account.
+- aud - did:key of an identity key. Enables to resolve associated Dapp domain used.
+- sub - blockchain account that this notify subscription is associated with (did:pkh)
+- scp - scope of notification types authorized by the user
+- app - dapp's domain url
+
+Expiry should be calculated from the addition of the issuance date and the notify request TTL (2592000 seconds)
+
+
+## Notify Update Response
+
+Once the Notify Server has successfully handled the incoming notify update request then it will acknowledge it by responding with a hash of the new subscription payload.
+
+- act - description of action intent. Must be equal to "notify_update_response"
+- iss - did:key of an identity key. Enables to resolve associated Dapp domain used.
+- aud - did:key of an identity key. Enables to resolve attached blockchain account.
+- sub - hash of the new subscription payload
+- app - dapp's domain url
+
+Expiry should be calculated from the addition of the issuance date and the notify request TTL (86400 seconds)
+
+## Notify Delete
+
+Once the Notify client wants to delete the subscription completely then it should authenticate the following request including the reason for deleting the subscription.
+
+- act - description of action intent. Must be equal to "notify_delete"
+- iss - did:key of an identity key. Enables to resolve attached blockchain account.
+- aud - did:key of an identity key. Enables to resolve associated Dapp domain used.
+- sub - reason for deleting the subscription
+- app - dapp's domain url
+
+## Notify Delete Response
+
+Once the Notify Server has sucessfully handled the subscription deletion then it should authenticate the following request including the hash of the existing subscription payload.
+
+- act - description of action intent. Must be equal to "notify_delete_response"
+- iss - did:key of an identity key. Enables to resolve associated Dapp domain used.
+- aud - did:key of an identity key. Enables to resolve attached blockchain account.
+- sub - hash of the existing subscription payload
+- app - dapp's domain url

--- a/docs/specs/clients/notify/notify-authentication.md
+++ b/docs/specs/clients/notify/notify-authentication.md
@@ -6,19 +6,21 @@ In this document we will describe the authentication payloads for different meth
 - Notify Subscription Response
 - Notify Message
 - Notify Receipt
-- Notify Update Response
-
+- Notify Subscription Update
+- Notify Subscription Update Response
+- Notify Subscription Delete
+- Notify Subscription Delete Response
 
 All of the above authentication payloads will share the following claims:
 
 - act - description of action intent. Must be equal to specific value defined in each payload
-- iat - timestamp when jwt was issued
-- exp - timestamp when jwt must expire
+- iat - timestamp when JWT was issued
+- exp - timestamp when JWT must expire
 - ksu - key server for identity key verification
 
 ## Notify Subscription
 
-The wallet creates a notify subscription by signing a JWT with the Identity Key corrresponding the blockchain account subscribed
+The wallet creates a notify subscription by signing a JWT with the dentity Key corrresponding the blockchain account subscribed
 
 This is achieved using [Identity Keys](../../servers/keys/identity-keys) and did-jwt with the following claims:
 
@@ -77,7 +79,7 @@ For each Notify message received, the Wallet will acknowledge its receipt with a
 
 Expiry should be calculated from the addition of the issuance date and the notify request TTL (86400 seconds)
 
-## Notify Update
+## Notify Subscription Update
 
 The wallet creates a notify update by signing a JWT with the Identity Key corrresponding the blockchain account subscribed
 
@@ -92,8 +94,7 @@ This is achieved using [Identity Keys](../../servers/keys/identity-keys) and did
 
 Expiry should be calculated from the addition of the issuance date and the notify request TTL (2592000 seconds)
 
-
-## Notify Update Response
+## Notify Subscription Update Response
 
 Once the Notify Server has successfully handled the incoming notify update request then it will acknowledge it by responding with a hash of the new subscription payload.
 
@@ -105,7 +106,7 @@ Once the Notify Server has successfully handled the incoming notify update reque
 
 Expiry should be calculated from the addition of the issuance date and the notify request TTL (86400 seconds)
 
-## Notify Delete
+## Notify Subscription Delete
 
 Once the Notify client wants to delete the subscription completely then it should authenticate the following request including the reason for deleting the subscription.
 
@@ -115,7 +116,7 @@ Once the Notify client wants to delete the subscription completely then it shoul
 - sub - reason for deleting the subscription
 - app - dapp's domain url
 
-## Notify Delete Response
+## Notify Subscription Delete Response
 
 Once the Notify Server has sucessfully handled the subscription deletion then it should authenticate the following request including the hash of the existing subscription payload.
 

--- a/docs/specs/clients/notify/notify-notification-types.md
+++ b/docs/specs/clients/notify/notify-notification-types.md
@@ -1,0 +1,82 @@
+# Notification Types
+
+Not every message is the same and not every wallet user wants to receive every possible notification that a dapp targets their wallet account.
+
+Notification Types define a scope of messages that the user authorizes the dapp to notify the user related to their wallet account.
+
+## Definitions
+
+A notification type includes a name and a description.
+
+A notification type name is a machine-readable lowercase string and not internationalized which matches the following regex: `[\w-/]{3,32}`.
+
+A notification type description is a human-readable case-sensitive string and not internationalized which matches the following regex: `[\w\s.]{3,100}`.
+
+
+## Configuration
+
+In order for dapps to expose their notification types they must store a static json file named `wc-notify-config.json` in their `.well-known` path under their domain url.
+
+The file should include the following schema:
+
+* version = schema version number
+* lastModified = date last modified in unix epoch timestamp in seconds
+* types = array of available types with `name` and `description` schema
+
+For example:
+
+```jsonc
+https://example.com/.well-known/wc-notify-config.json
+
+// wc-notify-config.json
+{
+  "version": 1,
+  "lastModified": 1681289416,
+  "types": [
+    {
+      "name": "promotional",
+      "description": "Get notified when new features or products are launched"
+    },
+    {
+      "name": "transactional",
+      "description": "Get notified when new on-chain transactions target your account"
+    },
+    {
+      "name": "private",
+      "description": "Get notified when new updates or offers are sent privately to your account"
+    },
+    {
+      "name": "alerts",
+      "description": "Get notified when urgent action is required from your account"
+    }
+  ]
+}
+```
+
+## Subscription Scope
+
+A Notify Subscription will include a claim labelled `scp` with a string value include the user authorized notification types separated by whitespaces.
+
+For example:
+
+```jsonc
+// did-jwt
+{
+  ...otherClaims
+  "scp": "promotional private alerts"
+}
+```
+
+## Notify Message
+
+A Notify Message will include a parameter called `type` in the message payload which indicates the notification type is being delivered to the wallet user
+
+```jsonc
+{
+  "title": string,
+  "body": string,
+  "icon": string,
+  "url": string,
+  "type": string // <--- notification type
+}
+```

--- a/docs/specs/clients/notify/notify-subscription.md
+++ b/docs/specs/clients/notify/notify-subscription.md
@@ -1,0 +1,43 @@
+# Notify Subscription
+
+A Notify subscription is an agreement between a dapp and a wallet to receive future notifications.
+
+A Wallet user will be able to authorize a dapp by sending an authenticated payload with a corresponding identity key and dapp URL as described by [Notify authentication](./notify-authentication.md)
+
+In order to create subscription a wallet is subscribed by the wallet and sent to the dapp using the Subscribe protocol which is described below.
+## User Flow
+
+The Notify subscribe flow will require a dapp to host a static json file which will contain a DID document compliant with `did:web` method as specified [here](https://w3c-ccg.github.io/did-method-web/). In this DID document we will specify a X25519 public key that will be used by the Notify API protocol to derive a symmetric key for the Notify topic.
+
+On the Wallet side we will be able to fetch a list of dapps that expose public keys for Notify subscribe from a registry as for example our WalletConnect Cloud Explorer. These public keys are generated on the Notify server which will be able to listen for new subscriptions sent by the wallet to the subscribe topic which is the sha256 hash of the public key exposed.
+
+Once the wallet user has selected the dapp which they intend to subscribe to, the wallet will be able to subscribe remotely without visiting the dapp.
+
+## Subscribe Protocol
+
+### Pre-requisites
+
+The Notify subscribe flow will require a dapp to host a static json file which will contain a DID document compliant with `did:web` method as specified [here](https://w3c-ccg.github.io/did-method-web/). In this DID document we will specify a X25519 public key that will be used by the Notify API protocol to derive a symmetric key for the Notify topic.
+
+
+### Protocol
+
+Subscribe protocol will be established as follows:
+
+1. Wallet fetches public key X from the did:web document
+2. Subscribe topic is derived from the sha256 hash of public key X
+3. Wallet generates key pair Y
+4. Wallet derives symmetric key S with keys X and Y
+5. Wallet sends notify subscribe request (type 1 envelope) on subscribe topic with subscriptionAuth
+6. Response topic is derived from the sha256 hash of symmetric key S
+7. Wallet subscribes to response topic
+8. Notify Server receives notify subscribe request on subscribe topic
+9. Notify Server derives symmetric key and decrypts subscriptionAuth
+10. Notify Server triggers webhook to notify Dapp of new registered address
+11. Notify Server generates key pair Z
+12. Notify Server derives symmetric key P with keys Y and Z
+13. Notify Server responds to notify subscribe request on response topic
+14. Wallet receives notify subscribe response on the response topic
+15. Wallet derives symmetric key P
+16. Notify topic is derived from the sha256 hash of the symmetric key P
+17. Wallet subscribes to notify topic for future notify messages

--- a/docs/specs/clients/notify/rpc-methods.md
+++ b/docs/specs/clients/notify/rpc-methods.md
@@ -1,0 +1,157 @@
+# RPC Methods
+
+This doc should be used as a _source-of-truth_ and reflect the latest decisions and changes applied to the WalletConnect collection of client-to-client JSON-RPC methods for all platforms SDKs.
+
+## Definitions
+
+- **Nullables:** Fields flagged as `Optional` can be omitted from the payload.
+- Unless explicitly mentioned that a response requires associated data, all methods response's follow a default JSON-RPC pattern for the success and failure cases:
+
+```jsonc
+// Success
+result: true
+
+// Failure
+error: {
+  "code": number,
+  "message": string
+}
+```
+
+## Methods
+
+### wc_notifySubscribe
+
+Used to subscribe notify subscription to a peer through subscribe topic. Response is expected on the response topic
+
+**Request**
+
+```jsonc
+// wc_notifySubscribe params
+{
+  "subscriptionAuth": string
+}
+
+| IRN     |          |
+| ------- | -------- | 
+| TTL     | 86400    |
+| Tag     | 4000     |
+
+```
+
+**Response**
+
+```jsonc
+// Success resu0t
+{
+  "responseAuth": string
+}
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Tag     | 4001     |
+```
+
+### wc_notifyMessage
+
+Used to publish a notification message to a peer through notify topic. Response is expected on the same topic.
+
+- Success response is equivalent to notify message acknowledgement.
+- Error response is equivalent to notify message failed to decrypt.
+
+
+**Request**
+
+```jsonc
+// wc_notifyMessage params
+{
+  "messageAuth": string
+}
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 2592000  |
+| Tag     | 4002     |
+
+```
+
+**Response**
+
+```jsonc
+// Success result
+{
+  "receiptAuth": string
+}
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 2592000  |
+| Tag     | 4003     |
+
+```
+
+### wc_notifyDelete
+
+Used to inform the peer to close and delete a notify subscription through notify topic. The reason field should be a human-readable message defined by the SDK consumer to be shown on the peer's side.
+
+**Request**
+
+```jsonc
+// wc_notifyDelete params
+{
+  "deleteAuth": string 
+}
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Tag     | 4004     |
+```
+
+**Response**
+
+```jsonc
+{
+  "responseAuth": string
+}
+true
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Tag     | 4005     |
+```
+
+### wc_notifyUpdate
+
+Used to update a notify subscription with a new notify subscription, replacing an existing notify subscription through notify topic.
+
+**Note:** this method is atomically performing two methods (wc_notifyDelete + wc_notifySubscribe)
+
+**Request**
+
+```jsonc
+// wc_notifyUpdate params
+{
+  "updateAuth": string // new subscription
+}
+
+| IRN     |          |
+| ------- | -------- | 
+| TTL     | 86400    |
+| Tag     | 4008     |
+
+```
+
+**Response**
+
+```jsonc
+// Success result
+{
+  "responseAuth": string
+}
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Tag     | 4009     |
+```

--- a/docs/specs/clients/notify/spam-protection.md
+++ b/docs/specs/clients/notify/spam-protection.md
@@ -1,0 +1,31 @@
+# Notify Spam Protection
+
+To ensure a positive end-user experience, it's essential to mitigate spam and
+protect users from [chat spam](../chat/spam-protection.md) and notification spam. This document outlines the measures taken to prevent spam and maintain a high-quality experience for end-users.
+
+Note, wallets and dapps implementing this SDK have the ability to expand on this
+protection due to the customizability of the SDK. An example of this is
+[Web3Inbox Spam Protection](../../meta-clients/web3inbox/spam-protection.md).
+
+## Innate Passive Protection
+
+These spam protections come prepackaged with the Notify SDK and require no
+additional configuration.
+
+### Notification Protection
+
+1. Limited notifications: Only one notification per dapp per hour is
+   allowed. This is to prevent dapps spamming a user as seen in Web2.
+2. Permissioned dapps: Initially, only vetted partners are allowed in the
+   program via our Cloud app.
+
+
+## User-Triggered Protection
+
+These spam protections come prepackaged with the Notify SDK but require action by
+the end user.
+
+### Notification Protection
+
+1. A user can unsubscribe from a dapp's notifications at any time. This is done
+   through the `deleteSubscription` function in the client.

--- a/docs/specs/clients/notify/usage-of-history-api.md
+++ b/docs/specs/clients/notify/usage-of-history-api.md
@@ -1,0 +1,20 @@
+# Cold start of Notify SDK with Archive API
+
+## Motivation
+
+A cold start represents the Notify SDK running for the first time on a device without any cached state. The account that is used for `enableSync` of NotifyClient API may already have some kind of history (notifySubscriptions, notifyMessages). The Archive API's purpose is to restore history and state after a cold start.
+
+Note: Launching a client after 30 days of inactivity is also considered a cold start
+
+## Implementation
+
+1. W1 already has some `notifySubscriptions`, `notifyMessages` history
+2. Wn performs cold start on different device but the same account as W1
+3. Wn configures sync for an account with `enableSync` method of NotifyClient
+4. Wn registers Archive API for `wc_syncSet`, `wc_syncDel` of SyncAPI methods and `notify_message` of Notify API method. Request tags can be found in [Sync API](../core/sync/rpc-methods.md) and [Notify API](./rpc-methods.md)specs
+5. Wn fetches sync messages containing NotifySubscription payloads. Topic to fetch and keys to decrypt payloads are derived according to [Sync API](../core/sync/readme.md). NotifySubscriptions description can be found in [NotifySubscriptions sync storage specs](./usage-of-sync-api.md)
+6. Wn combines `notifySubscriptions` inserts with deletions and updates the local database
+7. Wn subscribes for `notifySubscriptions` topics
+8. Wn sets subscription symKey P in keychain to be able to decrypt notifyMessages payloads
+9. Wn fetches `wc_notifyMessage` messages for every subscription topic from Archive API. Request tags can be found in [Notify RPC methods](./rpc-methods.md) 
+10. Wn decrypts notifyMessages payload with symKey P and updates local database

--- a/docs/specs/clients/notify/usage-of-sync-api.md
+++ b/docs/specs/clients/notify/usage-of-sync-api.md
@@ -1,0 +1,66 @@
+# Usage of Sync API
+
+In order to provide state synchronization between a user's devices we must add [Sync API](../core/sync/readme.md) support. As per Sync API requirements, the user [must sign an additional message](../core/sync/sync-protocol.md#generating-a-message-to-sign) to enable state synchronization. 
+
+## Stores 
+
+State synchronization is achieved by sharing the same key value stores among every client that the user
+registered in Notify API. For Notify API there are the following stores:
+
+
+### Notify Subscription Store
+
+#### Store Name
+`com.walletconnect.notify.notifySubscription`
+
+#### Store Key
+
+Key of [Notify Subscription Store](#notify-subscription-store) must be equal to `topic` from
+[`NotifySubscription`](#notifysubscription) data structure. 
+
+#### NotifySubscription
+
+```typescript
+interface NotifySubscription {
+    topic: string;
+    account: string;
+    relay: RelayerTypes.ProtocolOptions;
+    metadata: Metadata;
+    scope: ScopeMap;
+    expiry: number;
+    symKey: string;
+}
+```
+
+### Notify Subscription Protocol in multiclient environment
+
+#### Definitions
+- W1 - clients that have access to W (Wallet) blockchain account keys.
+- Wx - peer clients that have access to W (Wallet) blockchain account keys. 
+
+#### Pre-requisities
+The Notify subscribe flow will require a dapp to host a static json file which will contain a DID document compliant with `did:web` method as specified [here](https://w3c-ccg.github.io/did-method-web/). In this DID document we will specify a X25519 public key that will be used by the Notify API protocol to derive a symmetric key for the Notify topic.
+
+#### Protocol
+Subscribe protocol will be established as follows:
+
+1. W1 fetches public key X from the did:web document
+2. Subscribe topic is derived from the sha256 hash of public key X
+3. W1 generates key pair Y
+4. W1 derives symmetric key S with keys X and Y
+5. W1 sends notify subscribe request (type 1 envelope) on subscribe topic with subscriptionAuth
+7. Response topic is derived from the sha256 hash of symmetric key S
+8. W1 subscribes to response topic
+9. Cast Server receives notify subscribe request on subscribe topic
+10. Cast Server derives symmetric key S and decrypts subscriptionAuth
+11. Cast Server triggers webhook to notify Dapp of new registered address
+12. Cast Server generates key pair Z
+13. Cast Server derives symmetric key P with keys Y and Z
+14. Cast Server responds to notify subscribe request on response topic
+15. W1 receives notify subscribe response on the response topic
+16. W1 derives symmetric key P
+17. Notify topic is derived from the sha256 hash of the symmetric key P
+18. W1 subscribes to notify topic for future notify messages
+19. W1 syncs the notify subscription with Wx
+20. Wx stores the notify subscription
+21. Wx subscribe to notify topic coming from the sync request.

--- a/docs/specs/servers/notify/notify-server-api.md
+++ b/docs/specs/servers/notify/notify-server-api.md
@@ -1,0 +1,212 @@
+# Notify Server API
+
+## Register Account
+
+Registers an account and notify subscription symmetric key. The `subscriptionAuth` must be attached in the request so the Notify server can verify if wallet proved ownership of an address.
+
+`POST /register`
+
+Body:
+
+```jsonc
+{
+    "account": string,
+    "symKey": string,
+    "subscriptionAuth": string,
+    "relayUrl": string
+}
+```
+
+## Register Webhook
+
+Used to register a webhook that would return when accounts are subscribed or unsubscribed
+
+`POST /register-webhook`
+
+### Authentication
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+
+Body:
+
+```jsonc
+{
+    "events": string[], // subscribed or unsubscribed
+    "webhook": string
+}
+```
+
+Response:
+
+```jsonc
+{
+    "id": string
+}
+```
+
+Webhook payload:
+
+```jsonc
+{
+    "id": string,
+    "event": string, // subscribed or unsubscribed
+    "account": string, // CAIP-10 account
+    "dappUrl": string // dApp's URL with which the account was registered
+}
+```
+
+
+## Registered Webhooks
+
+Used to retrieve the list of registered webhooks
+
+`GET /webhooks`
+
+### Authentication
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+
+Response:
+
+```jsonc
+{
+  "<webhook_id1>": {
+    "url": "<webhook_url1>",
+    "events": [
+      "<event1>",
+      "<event2>",
+      ...
+    ]
+  },
+  "<webhook_id2>": {
+    "url": "<webhook_url2>",
+    "events": [
+      "<event1>",
+      ...
+    ]
+  },
+  ...
+}
+```
+
+
+## Update Webhook
+
+Used to update the registered webhook
+
+`PUT /webhooks/<webhook_id>`
+
+### Authentication
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+
+Body:
+
+```jsonc
+{
+    "events": string[], // subscribed or unsubscribed
+    "webhook": string
+} 
+```
+
+
+
+## Delete Webhook
+
+Used to delete the registered webhook
+
+`DELETE /webhooks/<webhook_id>`
+
+### Authentication
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+
+## Notify
+
+Used to notify a message to a set of accounts
+
+`POST /notify`
+
+### Authentication
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+
+Body:
+
+```jsonc
+{
+    "notification": {
+        "title": string,
+        "body": string,
+        "icon": string,
+        "url": string,
+        "type": string
+    },
+    "accounts": string[]
+}
+``` 
+
+Response: 
+
+```jsonc
+{
+  "sent": string[],
+  "failed": Failed[],
+  "notFound": string[]
+}
+```
+
+Failed:
+
+```jsonc
+{
+  "account": string,
+  "reason": string
+}
+```
+
+## Subscribe Topic
+
+Used to generate a subscribe topic for a dapp to receive notify subscriptions, returns a public key that should be stored on dapps's domain as a did:web document.
+
+**Note:** this method is idempotent and will always return the same key.
+
+`GET /subscribe-topic`
+
+### Authentication
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+
+Response:
+
+```jsonc
+{
+    "publicKey": string
+}
+``` 
+
+Failed:
+
+```jsonc
+{
+  "reason": string
+}
+```
+
+## Authentication Key
+
+Used to generate an authentication key for a dapp to send signed notify messages, returns a public key that should be stored on dapps's domain as a did:web document.
+
+**Note:** this method is idempotent and will always return the same key.
+
+`GET /authentication-key`
+
+Response:
+
+```jsonc
+{
+  "publicKey": string
+}
+``` 
+
+Failed:
+
+```jsonc
+{
+  "reason": string
+}
+```

--- a/docs/specs/servers/notify/notify-server-api.md
+++ b/docs/specs/servers/notify/notify-server-api.md
@@ -2,11 +2,11 @@
 
 ## Authentication
 
-All endpoints expect an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project ID. The secret used should be the one that was generated automatically when configuring notify - with the name `notify_subscribe_topic_private_key`
+All endpoints expect an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project ID. The secret used should be the one that was generated automatically when configuring notify - with the name `notify_subscribe_topic_private_key`.
 
 ## Notify
 
-Used to notify a message to a set of accounts
+Send a notification to a set of accounts.
 
 `POST /notify`
 
@@ -19,19 +19,25 @@ Body:
     "body": string,
     "icon": string,
     "url": string,
-    "type": string
+    "type": string,
   },
-  "accounts": string[]
+  "accounts": Account[],
 }
-``` 
+```
+
+Account:
+
+```typescript
+string
+```
 
 Response: 
 
 ```typescript
 {
-  "sent": string[],
-  "failed": Failed[],
-  "notFound": string[]
+  "sent": Account[], // notifications sent to subscribers
+  "failed": Failed[], // notifications not sent because there was a failure in delivering
+  "notFound": Account[], // notifications not sent becuase those accounts were not subscribers
 }
 ```
 
@@ -39,28 +45,26 @@ Failed:
 
 ```typescript
 {
-  "account": string,
-  "reason": string
+  "account": Account,
+  "reason": string,
 }
 ```
 
 ## Subscribers 
 
-Returns the list of all accounts currently subscribed to this dapp.
+Get the list of all accounts currently subscribed to this dapp.
 
 `GET /subscribers`
 
 Response:
 
 ```typescript
-{
-  []string
-}
+Account[]
 ``` 
 
 ## Subscribe Topic
 
-Used to generate a subscribe topic for a dapp to receive push subscriptions, returns a public key and identity key that should be stored on dapps's domain a did:web document. Requires the dapps url to be sent in the body.
+Used to generate a subscribe topic for a dapp to receive subscription requests from an account. Returns keys that should be stored on dapps's domain a did:web document.
 
 **Note:** this method is idempotent and will always return the same key.
 
@@ -70,7 +74,7 @@ Body:
 
 ```typescript
 {
-  "dappUrl": string
+  "dappUrl": string,
 }
 ``` 
 
@@ -79,56 +83,48 @@ Response:
 ```typescript
 {
   "identityPublicKey": string,
-  "subscribeTopicPublicKey": string 
+  "subscribeTopicPublicKey": string,
 }
 ``` 
 
-Failed:
-
-```typescript
-{
-  "reason": string
-}
-```
-
 ## Register Webhook
 
-Used to register a webhook that would return when accounts are subscribed or unsubscribed
+Register a webhook that will be invoked when accounts are subscribed or unsubscribed.
 
 `POST /register-webhook`
 
 Body:
 
 ```typescript
+Webhook
+```
+
+Webhook:
+
+```typescript
 {
-  "events": string[], // subscribed or unsubscribed
-  "webhook": string
+  "events": Event[], // set of Events
+  "url": string, // webhook URL
 }
+```
+
+Event:
+
+```typescript
+"subscribed" | "unsubscribed"
 ```
 
 Response:
 
 ```typescript
 {
-  "id": string
+  "id": string, // webhook ID
 }
 ```
-
-Webhook payload:
-
-```typescript
-{
-  "id": string,
-  "event": string, // subscribed or unsubscribed
-  "account": string, // CAIP-10 account
-  "dappUrl": string // dApp's URL with which the account was registered
-}
-```
-
 
 ## Registered Webhooks
 
-Used to retrieve the list of registered webhooks
+Get the list of registered webhooks.
 
 `GET /webhooks`
 
@@ -136,43 +132,30 @@ Response:
 
 ```typescript
 {
-  "<webhook_id1>": {
-    "url": "<webhook_url1>",
-    "events": [
-      "<event1>",
-      "<event2>",
-      ...
-    ]
-  },
-  "<webhook_id2>": {
-    "url": "<webhook_url2>",
-    "events": [
-      "<event1>",
-      ...
-    ]
-  },
+  "<webhook_id1>": Webhook,
+  "<webhook_id2>": Webhook,
   ...
 }
 ```
 
-
 ## Update Webhook
 
-Used to update the registered webhook
+Update a webhook.
 
 `PUT /webhooks/<webhook_id>`
 
 Body:
 
 ```typescript
-{
-  "events": string[], // subscribed or unsubscribed
-  "webhook": string
-} 
+Webhook
 ```
+
+No response.
 
 ## Delete Webhook
 
-Used to delete the registered webhook
+Delete a webhook.
 
 `DELETE /webhooks/<webhook_id>`
+
+No response.

--- a/docs/specs/servers/notify/notify-server-api.md
+++ b/docs/specs/servers/notify/notify-server-api.md
@@ -4,6 +4,46 @@
 
 All endpoints expect an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project ID. The secret used should be the one that was generated automatically when configuring notify - with the name `notify_subscribe_topic_private_key`
 
+## Notify
+
+Used to notify a message to a set of accounts
+
+`POST /notify`
+
+Body:
+
+```jsonc
+{
+  "notification": {
+    "title": string,
+    "body": string,
+    "icon": string,
+    "url": string,
+    "type": string
+  },
+  "accounts": string[]
+}
+``` 
+
+Response: 
+
+```jsonc
+{
+  "sent": string[],
+  "failed": Failed[],
+  "notFound": string[]
+}
+```
+
+Failed:
+
+```jsonc
+{
+  "account": string,
+  "reason": string
+}
+```
+
 ## Register Webhook
 
 Used to register a webhook that would return when accounts are subscribed or unsubscribed
@@ -91,46 +131,6 @@ Body:
 Used to delete the registered webhook
 
 `DELETE /webhooks/<webhook_id>`
-
-## Notify
-
-Used to notify a message to a set of accounts
-
-`POST /notify`
-
-Body:
-
-```jsonc
-{
-  "notification": {
-    "title": string,
-    "body": string,
-    "icon": string,
-    "url": string,
-    "type": string
-  },
-  "accounts": string[]
-}
-``` 
-
-Response: 
-
-```jsonc
-{
-  "sent": string[],
-  "failed": Failed[],
-  "notFound": string[]
-}
-```
-
-Failed:
-
-```jsonc
-{
-  "account": string,
-  "reason": string
-}
-```
 
 ## Subscribe Topic
 

--- a/docs/specs/servers/notify/notify-server-api.md
+++ b/docs/specs/servers/notify/notify-server-api.md
@@ -12,7 +12,7 @@ Used to notify a message to a set of accounts
 
 Body:
 
-```jsonc
+```typescript
 {
   "notification": {
     "title": string,
@@ -27,7 +27,7 @@ Body:
 
 Response: 
 
-```jsonc
+```typescript
 {
   "sent": string[],
   "failed": Failed[],
@@ -37,7 +37,7 @@ Response:
 
 Failed:
 
-```jsonc
+```typescript
 {
   "account": string,
   "reason": string
@@ -52,7 +52,7 @@ Returns the list of all accounts currently subscribed to this dapp.
 
 Response:
 
-```jsonc
+```typescript
 {
   []string
 }
@@ -68,7 +68,7 @@ Used to generate a subscribe topic for a dapp to receive push subscriptions, ret
 
 Body:
 
-```jsonc
+```typescript
 {
   "dappUrl": string
 }
@@ -76,7 +76,7 @@ Body:
 
 Response:
 
-```jsonc
+```typescript
 {
   "identityPublicKey": string,
   "subscribeTopicPublicKey": string 
@@ -85,7 +85,7 @@ Response:
 
 Failed:
 
-```jsonc
+```typescript
 {
   "reason": string
 }
@@ -99,7 +99,7 @@ Used to register a webhook that would return when accounts are subscribed or uns
 
 Body:
 
-```jsonc
+```typescript
 {
   "events": string[], // subscribed or unsubscribed
   "webhook": string
@@ -108,7 +108,7 @@ Body:
 
 Response:
 
-```jsonc
+```typescript
 {
   "id": string
 }
@@ -116,7 +116,7 @@ Response:
 
 Webhook payload:
 
-```jsonc
+```typescript
 {
   "id": string,
   "event": string, // subscribed or unsubscribed
@@ -134,7 +134,7 @@ Used to retrieve the list of registered webhooks
 
 Response:
 
-```jsonc
+```typescript
 {
   "<webhook_id1>": {
     "url": "<webhook_url1>",
@@ -164,7 +164,7 @@ Used to update the registered webhook
 
 Body:
 
-```jsonc
+```typescript
 {
   "events": string[], // subscribed or unsubscribed
   "webhook": string

--- a/docs/specs/servers/notify/notify-server-api.md
+++ b/docs/specs/servers/notify/notify-server-api.md
@@ -82,8 +82,8 @@ Response:
 
 ```typescript
 {
-  "identityPublicKey": string,
-  "subscribeTopicPublicKey": string,
+  "subscribeTopicPublicKey": string, // key agreement
+  "identityPublicKey": string, // authentication
 }
 ``` 
 
@@ -155,6 +155,8 @@ No response.
 ## Delete Webhook
 
 Delete a webhook.
+
+This method is idempotent. If webhook ID does not exist, the request will still be successful.
 
 `DELETE /webhooks/<webhook_id>`
 

--- a/docs/specs/servers/notify/notify-server-api.md
+++ b/docs/specs/servers/notify/notify-server-api.md
@@ -1,22 +1,5 @@
 # Notify Server API
 
-## Register Account
-
-Registers an account and notify subscription symmetric key. The `subscriptionAuth` must be attached in the request so the Notify server can verify if wallet proved ownership of an address.
-
-`POST /register`
-
-Body:
-
-```jsonc
-{
-    "account": string,
-    "symKey": string,
-    "subscriptionAuth": string,
-    "relayUrl": string
-}
-```
-
 ## Register Webhook
 
 Used to register a webhook that would return when accounts are subscribed or unsubscribed
@@ -24,7 +7,7 @@ Used to register a webhook that would return when accounts are subscribed or uns
 `POST /register-webhook`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name `notify_subscribe_topic_private_key`  
 
 Body:
 
@@ -62,7 +45,7 @@ Used to retrieve the list of registered webhooks
 `GET /webhooks`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 Response:
 
@@ -95,7 +78,7 @@ Used to update the registered webhook
 `PUT /webhooks/<webhook_id>`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 Body:
 
@@ -115,7 +98,7 @@ Used to delete the registered webhook
 `DELETE /webhooks/<webhook_id>`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 ## Notify
 
@@ -124,7 +107,7 @@ Used to notify a message to a set of accounts
 `POST /notify`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 Body:
 
@@ -162,20 +145,29 @@ Failed:
 
 ## Subscribe Topic
 
-Used to generate a subscribe topic for a dapp to receive notify subscriptions, returns a public key that should be stored on dapps's domain as a did:web document.
+Used to generate a subscribe topic for a dapp to receive push subscriptions, returns a public key and identity key that should be stored on dapps's domain a did:web document. Requires the dapps url to be sent in the body.
 
 **Note:** this method is idempotent and will always return the same key.
 
-`GET /subscribe-topic`
+`POST /subscribe-topic`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+
+Body:
+
+```jsonc
+{
+    "dappUrl": string
+}
+``` 
 
 Response:
 
 ```jsonc
 {
-    "publicKey": string
+  "identityPublicKey": string,
+  "subscribeTopicPublicKey": string 
 }
 ``` 
 
@@ -187,26 +179,21 @@ Failed:
 }
 ```
 
-## Authentication Key
+## Subscribers 
 
-Used to generate an authentication key for a dapp to send signed notify messages, returns a public key that should be stored on dapps's domain as a did:web document.
+Returns the list of all accounts currently subscribed to this dapp.
 
-**Note:** this method is idempotent and will always return the same key.
+`GET /subscribers`
 
-`GET /authentication-key`
+### Authentication
+Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 Response:
 
 ```jsonc
 {
-  "publicKey": string
+  []string
 }
 ``` 
 
-Failed:
 
-```jsonc
-{
-  "reason": string
-}
-```

--- a/docs/specs/servers/notify/notify-server-api.md
+++ b/docs/specs/servers/notify/notify-server-api.md
@@ -1,13 +1,14 @@
 # Notify Server API
 
+## Authentication
+
+All endpoints expect an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project ID. The secret used should be the one that was generated automatically when configuring notify - with the name `notify_subscribe_topic_private_key`
+
 ## Register Webhook
 
 Used to register a webhook that would return when accounts are subscribed or unsubscribed
 
 `POST /register-webhook`
-
-### Authentication
-Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name `notify_subscribe_topic_private_key`  
 
 Body:
 
@@ -44,9 +45,6 @@ Used to retrieve the list of registered webhooks
 
 `GET /webhooks`
 
-### Authentication
-Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
-
 Response:
 
 ```jsonc
@@ -77,9 +75,6 @@ Used to update the registered webhook
 
 `PUT /webhooks/<webhook_id>`
 
-### Authentication
-Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
-
 Body:
 
 ```jsonc
@@ -97,17 +92,11 @@ Used to delete the registered webhook
 
 `DELETE /webhooks/<webhook_id>`
 
-### Authentication
-Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
-
 ## Notify
 
 Used to notify a message to a set of accounts
 
 `POST /notify`
-
-### Authentication
-Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 Body:
 
@@ -151,9 +140,6 @@ Used to generate a subscribe topic for a dapp to receive push subscriptions, ret
 
 `POST /subscribe-topic`
 
-### Authentication
-Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
-
 Body:
 
 ```jsonc
@@ -184,9 +170,6 @@ Failed:
 Returns the list of all accounts currently subscribed to this dapp.
 
 `GET /subscribers`
-
-### Authentication
-Notify server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 Response:
 

--- a/docs/specs/servers/notify/notify-server-api.md
+++ b/docs/specs/servers/notify/notify-server-api.md
@@ -13,8 +13,8 @@ Body:
 
 ```jsonc
 {
-    "events": string[], // subscribed or unsubscribed
-    "webhook": string
+  "events": string[], // subscribed or unsubscribed
+  "webhook": string
 }
 ```
 
@@ -22,7 +22,7 @@ Response:
 
 ```jsonc
 {
-    "id": string
+  "id": string
 }
 ```
 
@@ -30,10 +30,10 @@ Webhook payload:
 
 ```jsonc
 {
-    "id": string,
-    "event": string, // subscribed or unsubscribed
-    "account": string, // CAIP-10 account
-    "dappUrl": string // dApp's URL with which the account was registered
+  "id": string,
+  "event": string, // subscribed or unsubscribed
+  "account": string, // CAIP-10 account
+  "dappUrl": string // dApp's URL with which the account was registered
 }
 ```
 
@@ -84,8 +84,8 @@ Body:
 
 ```jsonc
 {
-    "events": string[], // subscribed or unsubscribed
-    "webhook": string
+  "events": string[], // subscribed or unsubscribed
+  "webhook": string
 } 
 ```
 
@@ -113,14 +113,14 @@ Body:
 
 ```jsonc
 {
-    "notification": {
-        "title": string,
-        "body": string,
-        "icon": string,
-        "url": string,
-        "type": string
-    },
-    "accounts": string[]
+  "notification": {
+    "title": string,
+    "body": string,
+    "icon": string,
+    "url": string,
+    "type": string
+  },
+  "accounts": string[]
 }
 ``` 
 
@@ -158,7 +158,7 @@ Body:
 
 ```jsonc
 {
-    "dappUrl": string
+  "dappUrl": string
 }
 ``` 
 
@@ -195,5 +195,3 @@ Response:
   []string
 }
 ``` 
-
-

--- a/docs/specs/servers/notify/notify-server-api.md
+++ b/docs/specs/servers/notify/notify-server-api.md
@@ -44,6 +44,53 @@ Failed:
 }
 ```
 
+## Subscribers 
+
+Returns the list of all accounts currently subscribed to this dapp.
+
+`GET /subscribers`
+
+Response:
+
+```jsonc
+{
+  []string
+}
+``` 
+
+## Subscribe Topic
+
+Used to generate a subscribe topic for a dapp to receive push subscriptions, returns a public key and identity key that should be stored on dapps's domain a did:web document. Requires the dapps url to be sent in the body.
+
+**Note:** this method is idempotent and will always return the same key.
+
+`POST /subscribe-topic`
+
+Body:
+
+```jsonc
+{
+  "dappUrl": string
+}
+``` 
+
+Response:
+
+```jsonc
+{
+  "identityPublicKey": string,
+  "subscribeTopicPublicKey": string 
+}
+``` 
+
+Failed:
+
+```jsonc
+{
+  "reason": string
+}
+```
+
 ## Register Webhook
 
 Used to register a webhook that would return when accounts are subscribed or unsubscribed
@@ -124,57 +171,8 @@ Body:
 } 
 ```
 
-
-
 ## Delete Webhook
 
 Used to delete the registered webhook
 
 `DELETE /webhooks/<webhook_id>`
-
-## Subscribe Topic
-
-Used to generate a subscribe topic for a dapp to receive push subscriptions, returns a public key and identity key that should be stored on dapps's domain a did:web document. Requires the dapps url to be sent in the body.
-
-**Note:** this method is idempotent and will always return the same key.
-
-`POST /subscribe-topic`
-
-Body:
-
-```jsonc
-{
-  "dappUrl": string
-}
-``` 
-
-Response:
-
-```jsonc
-{
-  "identityPublicKey": string,
-  "subscribeTopicPublicKey": string 
-}
-``` 
-
-Failed:
-
-```jsonc
-{
-  "reason": string
-}
-```
-
-## Subscribers 
-
-Returns the list of all accounts currently subscribed to this dapp.
-
-`GET /subscribers`
-
-Response:
-
-```jsonc
-{
-  []string
-}
-``` 


### PR DESCRIPTION
- Move the notify specs from walletconnect-docs repo.
- Pull changes from https://github.com/WalletConnect/walletconnect-docs/pull/859
- Made further fixes and improvements to:
  - notify-server-api.md
  - notify-authentication.md
  - dapp-authentication.md