### PR TITLE
feat: update TTLs

### DIFF
--- a/docs/specs/clients/notify/notify-authentication.md
+++ b/docs/specs/clients/notify/notify-authentication.md
@@ -11,7 +11,7 @@ In this document we will describe the authentication payloads for different meth
 - Notify Subscription Delete
 - Notify Subscription Delete Response
 
-All of the above authentication payloads are did-jwts and share the following claims:
+All of the above authentication payloads are DID JWTs and share the following claims:
 
 - act - description of action intent. Must be equal to specific value defined in each payload
 - iat - timestamp when JWT was issued

--- a/docs/specs/clients/notify/notify-authentication.md
+++ b/docs/specs/clients/notify/notify-authentication.md
@@ -26,7 +26,7 @@ JWT TTLs must be equal to the message TTLs they are sent on.
 
 If a client receives a JWT that is expired, it must ignore it as if it was never received. This is to ensure there are no race conditions between message TTL and JWT TTL.
 
-Another potential way to avoid the race condition is for the sender to set the message TTL to slightly less than the JWT TTL, however this is not ideal (and must not be done) as message TTL is a releative time from when the relay receives the message and not absolute like the JWT expiration is.
+A non-ideal way to avoid the race condition is for the sender to set the message TTL to slightly less than the JWT TTL, however this must not be done as message TTL is a relative time from when the relay receives the message and not absolute like the JWT expiration is.
 
 ## Notify Subscription
 

--- a/docs/specs/clients/notify/notify-authentication.md
+++ b/docs/specs/clients/notify/notify-authentication.md
@@ -11,18 +11,26 @@ In this document we will describe the authentication payloads for different meth
 - Notify Subscription Delete
 - Notify Subscription Delete Response
 
-All of the above authentication payloads will share the following claims:
+All of the above authentication payloads are did-jwts and share the following claims:
 
 - act - description of action intent. Must be equal to specific value defined in each payload
 - iat - timestamp when JWT was issued
-- exp - timestamp when JWT must expire
+- exp - timestamp when JWT must expire. Must be equal to specific TTL defined in each payload, plus the iat value
 - ksu - key server for identity key verification
+
+This is achieved using [Dapp Authentication](./dapp-authentication.md) keys which are exposed by the Notify Server but hosted on the Dapp's domain. Also involving [Identity Keys](../../servers/keys/identity-keys).
+
+## Expired JWT handling
+
+JWT TTLs must be equal to the message TTLs they are sent on.
+
+If a client receives a JWT that is expired, it must ignore it as if it was never received. This is to ensure there are no race conditions between message TTL and JWT TTL.
+
+Another potential way to avoid the race condition is for the sender to set the message TTL to slightly less than the JWT TTL, however this is not ideal (and must not be done) as message TTL is a releative time from when the relay receives the message and not absolute like the JWT expiration is.
 
 ## Notify Subscription
 
 The wallet creates a notify subscription by signing a JWT with the dentity Key corrresponding the blockchain account subscribed
-
-This is achieved using [Identity Keys](../../servers/keys/identity-keys) and did-jwt with the following claims:
 
 - act - description of action intent. Must be equal to "notify_subscription"
 - iss - did:key of an identity key. Enables to resolve attached blockchain account.
@@ -31,7 +39,7 @@ This is achieved using [Identity Keys](../../servers/keys/identity-keys) and did
 - scp - scope of notification types authorized by the user
 - app - dapp's domain url
 
-Expiry should be calculated from the addition of the issuance date and the notify request TTL (2592000 seconds)
+TTL: 30 seconds
 
 ## Notify Subscription Response
 
@@ -43,15 +51,11 @@ Once the Notify Server has successfully handled the incoming notify subscription
 - sub - did:key of the public key used for key agreement on the Notify topic 
 - app - dapp's domain url
 
-Expiry should be calculated from the addition of the issuance date and the notify request TTL (86400 seconds)
+TTL: 2592000 seconds (30 days)
 
 ## Notify Message
 
 For each Notify message sent, the Dapp will have an authenticated payload signed by the chosen Notify Server which will have associated an authentication key for each Dapp domain.
-
-This is achieved using [Dapp Authentication](./dapp-authentication.md) keys which are exposed by the Notify Server but hosted on the Dapp's domain.
-
-The message payload is a did-jwt with the following claims:
 
 - act - description of action intent. Must be equal to "notify_message"
 - iss - did:key of an identity key. Enables to resolve associated Dapp domain used.
@@ -65,7 +69,7 @@ The message payload is a did-jwt with the following claims:
     - url -  redirect url for call-to-action related to notification
     - type - notification type which matches the scope of notify subscription
 
-Expiry should be calculated from the addition of the issuance date and the notify request TTL (86400 seconds)
+TTL: 2592000 seconds (30 days)
 
 ## Notify Receipt
 
@@ -77,13 +81,11 @@ For each Notify message received, the Wallet will acknowledge its receipt with a
 - sub - hash of the stringified notify message object received
 - app - dapp's domain url
 
-Expiry should be calculated from the addition of the issuance date and the notify request TTL (86400 seconds)
+TTL: 2592000 seconds (30 days)
 
 ## Notify Subscription Update
 
 The wallet creates a notify update by signing a JWT with the Identity Key corrresponding the blockchain account subscribed
-
-This is achieved using [Identity Keys](../../servers/keys/identity-keys) and did-jwt with the following claims:
 
 - act - description of action intent. Must be equal to "notify_update"
 - iss - did:key of an identity key. Enables to resolve attached blockchain account.
@@ -92,7 +94,7 @@ This is achieved using [Identity Keys](../../servers/keys/identity-keys) and did
 - scp - scope of notification types authorized by the user
 - app - dapp's domain url
 
-Expiry should be calculated from the addition of the issuance date and the notify request TTL (2592000 seconds)
+TTL: 30 seconds
 
 ## Notify Subscription Update Response
 
@@ -104,7 +106,7 @@ Once the Notify Server has successfully handled the incoming notify update reque
 - sub - hash of the new subscription payload
 - app - dapp's domain url
 
-Expiry should be calculated from the addition of the issuance date and the notify request TTL (86400 seconds)
+TTL: 2592000 seconds (30 days)
 
 ## Notify Subscription Delete
 
@@ -116,6 +118,8 @@ Once the Notify client wants to delete the subscription completely then it shoul
 - sub - reason for deleting the subscription
 - app - dapp's domain url
 
+TTL: 2592000 seconds (30 days)
+
 ## Notify Subscription Delete Response
 
 Once the Notify Server has sucessfully handled the subscription deletion then it should authenticate the following request including the hash of the existing subscription payload.
@@ -125,3 +129,5 @@ Once the Notify Server has sucessfully handled the subscription deletion then it
 - aud - did:key of an identity key. Enables to resolve attached blockchain account.
 - sub - hash of the existing subscription payload
 - app - dapp's domain url
+
+TTL: 2592000 seconds (30 days)

--- a/docs/specs/clients/notify/rpc-methods.md
+++ b/docs/specs/clients/notify/rpc-methods.md
@@ -34,9 +34,8 @@ Used to subscribe notify subscription to a peer through subscribe topic. Respons
 
 | IRN     |          |
 | ------- | -------- | 
-| TTL     | 86400    |
+| TTL     | 30       |
 | Tag     | 4000     |
-
 ```
 
 **Response**
@@ -49,7 +48,7 @@ Used to subscribe notify subscription to a peer through subscribe topic. Respons
 
 | IRN     |          |
 | ------- | -------- |
-| TTL     | 86400    |
+| TTL     | 2592000  |
 | Tag     | 4001     |
 ```
 
@@ -73,7 +72,6 @@ Used to publish a notification message to a peer through notify topic. Response 
 | ------- | -------- |
 | TTL     | 2592000  |
 | Tag     | 4002     |
-
 ```
 
 **Response**
@@ -88,7 +86,6 @@ Used to publish a notification message to a peer through notify topic. Response 
 | ------- | -------- |
 | TTL     | 2592000  |
 | Tag     | 4003     |
-
 ```
 
 ### wc_notifyDelete
@@ -104,7 +101,7 @@ Used to inform the peer to close and delete a notify subscription through notify
 }
 | IRN     |          |
 | ------- | -------- |
-| TTL     | 86400    |
+| TTL     | 2592000  |
 | Tag     | 4004     |
 ```
 
@@ -117,7 +114,7 @@ Used to inform the peer to close and delete a notify subscription through notify
 true
 | IRN     |          |
 | ------- | -------- |
-| TTL     | 86400    |
+| TTL     | 2592000  |
 | Tag     | 4005     |
 ```
 
@@ -137,9 +134,8 @@ Used to update a notify subscription with a new notify subscription, replacing a
 
 | IRN     |          |
 | ------- | -------- | 
-| TTL     | 86400    |
+| TTL     | 30       |
 | Tag     | 4008     |
-
 ```
 
 **Response**
@@ -152,6 +148,6 @@ Used to update a notify subscription with a new notify subscription, replacing a
 
 | IRN     |          |
 | ------- | -------- |
-| TTL     | 86400    |
+| TTL     | 2592000  |
 | Tag     | 4009     |
 ```

--- a/docs/specs/clients/notify/rpc-methods.md
+++ b/docs/specs/clients/notify/rpc-methods.md
@@ -92,7 +92,7 @@ Used to publish a notification message to a peer through notify topic. Response 
 
 Used to inform the peer to close and delete a notify subscription through notify topic. The reason field should be a human-readable message defined by the SDK consumer to be shown on the peer's side.
 
-Note: If the Notify Server is offline when the delete request is sent, the relay will retain the message the mailbox. The TTL is set such that when the Notify Server comes back online the delete request will be received. The message expiration is equal to the expiration of the subscription itself. Notify clients should assume deletion is successful as long as the relay ACKs the message. The delete response is for informational purposes and does not need to be received.
+Note: If the Notify Server is offline when the delete request is sent, the relay will retain the message in the mailbox. The TTL is set such that when Notify Server comes back online, the delete request will be received. The message expiration is equal to the expiration of the subscription itself. Notify clients should assume deletion is successful as long as the relay ACKs the message. The delete response is for informational purposes and does not need to be received.
 
 **Request**
 

--- a/docs/specs/clients/notify/rpc-methods.md
+++ b/docs/specs/clients/notify/rpc-methods.md
@@ -92,6 +92,8 @@ Used to publish a notification message to a peer through notify topic. Response 
 
 Used to inform the peer to close and delete a notify subscription through notify topic. The reason field should be a human-readable message defined by the SDK consumer to be shown on the peer's side.
 
+Note: If the Notify Server is offline when the delete request is sent, the relay will retain the message the mailbox. The TTL is set such that when the Notify Server comes back online the delete request will be received. The message expiration is equal to the expiration of the subscription itself. Notify clients should assume deletion is successful as long as the relay ACKs the message. The delete response is for informational purposes and does not need to be received.
+
 **Request**
 
 ```jsonc


### PR DESCRIPTION
Update notify message TTLs as per discussion today.

- JWT and message TTLs are equal
- How to handle race condition between JWT and message TTLs
- All responses (subscription response, subscription update response, subscription delete response, notify receipt) have 30 day TTLs to make sure the other side is able to receive them
- Message TTL remains 30 days to ensure the client receives it
- Subscription delete request TTL increased to 30 days to ensure notify server receives it (subscription expires after 30 days anyway), even if device submits it optimistically
- Subscription request and subscription update request TTLs reduced to 30 seconds to avoid unexpected changes with a subscription being created or updated days after the client submitted it