### PR TITLE
Make icon and url not nullable again

### DIFF
--- a/docs/specs/clients/notify/data-structures.md
+++ b/docs/specs/clients/notify/data-structures.md
@@ -28,7 +28,7 @@
   body: string,
   // Image URL used to display with the notification. If empty, the app's icon from Notify Config is used instead
   icon: string,
-  // Redirect URL for call-to-action related to notification.
+  // Redirect URL for call-to-action related to notification. If empty, do not redirect
   url: string,
 }
 ```

--- a/docs/specs/clients/notify/data-structures.md
+++ b/docs/specs/clients/notify/data-structures.md
@@ -26,10 +26,10 @@
   title: string,
   // Long messages used in the body of the notification
   body: string,
-  // Image URL used to display with the notification. If null, the app's icon from Notify Config is used instead
-  icon: string | null,
-  // Redirect URL for call-to-action related to notification
-  url: string | null,
+  // Image URL used to display with the notification. If empty, the app's icon from Notify Config is used instead
+  icon: string,
+  // Redirect URL for call-to-action related to notification.
+  url: string,
 }
 ```
 


### PR DESCRIPTION
We have to revert this as this is a breaking change on older clients. Since Notify should no longer have too many braking changes we cannot make this change anymore