### PR TITLE
Make `isRegistered` take same params as `prepareRegistration` to check registration status accurately

### DIFF
--- a/docs/specs/clients/notify/client-sdk-api.md
+++ b/docs/specs/clients/notify/client-sdk-api.md
@@ -83,7 +83,9 @@ abstract class Client {
   
   // Returns true if account has a valid and up to date registration, false otherwise
   public abstract isRegistered(params: {
-    account: string
+    account: string,
+    allApps: boolean,
+    domain: string
   }): boolean
 
   // "Logs out" this client from any notifications for the specified account. This involves:


### PR DESCRIPTION
Make `isRegistered` take same params as `prepareRegistration` to check registration status accurately