### PR TITLE
feat: subs in subscribe response & versioning information

### DIFF
--- a/docs/specs/clients/notify/authentication.md
+++ b/docs/specs/clients/notify/authentication.md
@@ -11,7 +11,6 @@ All of the authentication payloads are DID JWTs and share the following claims:
 - sub - did:pkh of blockchain account that this request is associated with
   - Example: `did:pkh:eip155:1:0x1234...`
 - mjv - major version of the API level being used as a string, currently `"1"`
-- sdk - SDK and version, for example: `js-2.10.5`
 
 Depending on the message, different keys are used for `iss`:
 - "iss - did:key of client identity key" indicates JWTs sent by clients and are verified by the Notify Server with [Identity Keys](../core/identity/identity-keys.md).

--- a/docs/specs/clients/notify/authentication.md
+++ b/docs/specs/clients/notify/authentication.md
@@ -10,6 +10,8 @@ All of the authentication payloads are DID JWTs and share the following claims:
 - iss - did:key. Value defined specifically in each payload
 - sub - did:pkh of blockchain account that this request is associated with
   - Example: `did:pkh:eip155:1:0x1234...`
+- mjv - major version of the API level being used as a string, currently `"1"`
+- sdk - SDK and version, for Notify Server this is always `notify-server-1`. For example: `js-2.10.5`
 
 Depending on the message, different keys are used for `iss`:
 - "iss - did:key of client identity key" indicates JWTs sent by clients and are verified by the Notify Server with [Identity Keys](../core/identity/identity-keys.md).
@@ -71,6 +73,7 @@ A non-ideal way to avoid the race condition is for the sender to set the message
 - aud - did:key of client identity key
 - app - did:web of app domain that this request is associated with 
   - Example: `did:web:app.example.com`
+- sbs - array of [Notify Server Subscriptions](./data-structures.md#notify-server-subscriptions)
 
 ## wc_notifyMessage request
 

--- a/docs/specs/clients/notify/authentication.md
+++ b/docs/specs/clients/notify/authentication.md
@@ -109,6 +109,7 @@ A non-ideal way to avoid the race condition is for the sender to set the message
 - aud - did:key of client identity key
 - app - did:web of app domain that this request is associated with 
   - Example: `did:web:app.example.com`
+- sbs - array of [Notify Server Subscriptions](./data-structures.md#notify-server-subscriptions)
 
 ## wc_notifyDelete request
 
@@ -126,3 +127,4 @@ A non-ideal way to avoid the race condition is for the sender to set the message
 - aud - did:key of client identity key
 - app - did:web of app domain that this request is associated with 
   - Example: `did:web:app.example.com`
+- sbs - array of [Notify Server Subscriptions](./data-structures.md#notify-server-subscriptions)

--- a/docs/specs/clients/notify/authentication.md
+++ b/docs/specs/clients/notify/authentication.md
@@ -11,7 +11,7 @@ All of the authentication payloads are DID JWTs and share the following claims:
 - sub - did:pkh of blockchain account that this request is associated with
   - Example: `did:pkh:eip155:1:0x1234...`
 - mjv - major version of the API level being used as a string, currently `"1"`
-- sdk - SDK and version, for Notify Server this is always `notify-server-1`. For example: `js-2.10.5`
+- sdk - SDK and version, for example: `js-2.10.5`
 
 Depending on the message, different keys are used for `iss`:
 - "iss - did:key of client identity key" indicates JWTs sent by clients and are verified by the Notify Server with [Identity Keys](../core/identity/identity-keys.md).

--- a/docs/specs/clients/notify/rpc-methods.md
+++ b/docs/specs/clients/notify/rpc-methods.md
@@ -54,6 +54,8 @@ Calling this method will create a "watcher" on the Notify Server for the given a
 
 If this method is called again with the same `iss`, it will update the watcher with the new account and `app`, reset the watcher timeout, and re-derive the symkey/topic from the current `kY` and Notify Keys. Clients should re-use the same `iss` and `kY` for the same account on the same device to avoid abandoned topics and improve performance. To watch multiple accounts at the same time, separate `iss` and `kY` must be used for each account otherwise it will either update the account and `app` being watched (if `iss` is the same), or result in receiving updates for multiple accounts on the same topic (if `kY` is the same).
 
+Watchers will only be notified of changes from _other_ clients. I.e. if a subscription change is made by `iss1`, then as a response to that `iss1`'s request the latest subscriptions will be provided. But it will not receive a `wc_notifySubscriptionsChanged` request.
+
 **Request**
 
 ```jsonc

--- a/docs/specs/clients/notify/rpc-methods.md
+++ b/docs/specs/clients/notify/rpc-methods.md
@@ -54,7 +54,7 @@ Calling this method will create a "watcher" on the Notify Server for the given a
 
 If this method is called again with the same `iss`, it will update the watcher with the new account and `app`, reset the watcher timeout, and re-derive the symkey/topic from the current `kY` and Notify Keys. Clients should re-use the same `iss` and `kY` for the same account on the same device to avoid abandoned topics and improve performance. To watch multiple accounts at the same time, separate `iss` and `kY` must be used for each account otherwise it will either update the account and `app` being watched (if `iss` is the same), or result in receiving updates for multiple accounts on the same topic (if `kY` is the same).
 
-Watchers will only be notified of changes from _other_ clients. I.e. if a subscription change is made by `iss1`, then as a response to that `iss1`'s request the latest subscriptions will be provided. But it will not receive a `wc_notifySubscriptionsChanged` request.
+Watchers will only be notified of changes from _other_ clients. I.e. if a subscription change is made by `iss`, then as a response to that `iss`'s request the latest subscriptions will be provided. But it will not receive a `wc_notifySubscriptionsChanged` request.
 
 **Request**
 


### PR DESCRIPTION
- Adds `sbs` which is the list of subscriptions to `notifySubscribe`, `notifyUpdate`, and `notifyDelete` responses to simplify client-side implementation to avoid listening for an additional subscriptionsChanged. [Context](https://walletconnect.slack.com/archives/C044SKFKELR/p1701870285066439?thread_ts=1701804693.064159&cid=C044SKFKELR).
- Adds `mjv` to all JWTs which enables each side to tell what version the other side is using and if there have been any major breaking changes to the API in-use.
  - Notify Server can use this to tell if a client supports the new `sbs` response field and thus will avoid sending a duplicate subscriptionsChanged request to supporting clients
  - Clients can use this to tell if Notify Server has broken support for an old API version, and for clients to fail more gracefully such as logging "please update your SDK version". For example this could happen if support for an insecure SIWE statement is dropped, or there are other major protocol improvements that need to be made and support dropped after a sufficient majority of clients migrate.
- ~~Adds `sdk` versioning information for analytics purposes~~