### PR TITLE
Hedera - fix formatting and typos / errors in examples

### DIFF
--- a/docs/blockchain-rpc/hedera-rpc.md
+++ b/docs/blockchain-rpc/hedera-rpc.md
@@ -8,17 +8,16 @@ The following JSON-RPC methods offer native integration into Hedera utilizing th
 
 Hedera documentation can be found at [docs.hedera.com](https://docs.hedera.com/hedera/).
 
-The following resources provide specific information referenced in the methods below. 
+The following resources provide specific information referenced in the methods below.
 
- - The Hedera network structure is summarized by [Mainnet Nodes](https://docs.hedera.com/hedera/networks/mainnet/mainnet-nodes)
- - The full list of Hedera functionality is described by the protobuf definitions: [Hedera Functionality](https://hashgraph.github.io/hedera-protobufs/#proto.HederaFunctionality)
- - Further details about these methods can be found in the accompanying Hedera Improvement Proposal: [HIP-820](https://hips.hedera.com/hip/hip-820)
- - The `signerAccountId` utilized in the methods below is specified by [HIP-30](https://hips.hedera.com/hip/hip-30)
- - A Hedera Transaction ID is composed of the account id that pays for a transaction and the valid start timestamp in nanoseconds: [Hedera Transaction ID](https://docs.hedera.com/hedera/sdks-and-apis/sdks/transactions/transaction-id)
- - There are pre-processing validation response codes returned by the network: [ResponseCodeEnum](https://github.com/hashgraph/hedera-protobufs/blob/f36e05bd6bf3f572707ca9bb338f5ad6421a4241/services/response_code.proto#L32)
+- The Hedera network structure is summarized by [Mainnet Nodes](https://docs.hedera.com/hedera/networks/mainnet/mainnet-nodes)
+- The full list of Hedera functionality is described by the protobuf definitions: [Hedera Functionality](https://hashgraph.github.io/hedera-protobufs/#proto.HederaFunctionality)
+- Further details about these methods can be found in the accompanying Hedera Improvement Proposal: [HIP-820](https://hips.hedera.com/hip/hip-820)
+- The `signerAccountId` utilized in the methods below is specified by [HIP-30](https://hips.hedera.com/hip/hip-30)
+- A Hedera Transaction ID is composed of the account id that pays for a transaction and the valid start timestamp in nanoseconds: [Hedera Transaction ID](https://docs.hedera.com/hedera/sdks-and-apis/sdks/transactions/transaction-id)
+- There are pre-processing validation response codes returned by the network: [ResponseCodeEnum](https://github.com/hashgraph/hedera-protobufs/blob/f36e05bd6bf3f572707ca9bb338f5ad6421a4241/services/response_code.proto#L32)
 
-
- _Hedera has a separate open-source project implementing parts of the [Ethereum JSON-RPC standard](https://docs.hedera.com/hedera/core-concepts/smart-contracts/json-rpc-relay) which is not covered in this documentation._
+_Hedera has a separate open-source project implementing parts of the [Ethereum JSON-RPC standard](https://docs.hedera.com/hedera/core-concepts/smart-contracts/json-rpc-relay) which is not covered in this documentation._
 
 ## Methods
 
@@ -37,13 +36,11 @@ The dApp then constructs a list of valid transaction bytes that differ only in t
 
 Wallets and SDKs must take special care to deserialize the list of transactions and validate that each transaction in the list differs only in the node authorized to receive the transaction and does NOT differ in intent before submitting to an end user for approval and ultimately signing.
 
-
 ### Parameters
 
     1. `Object` - signAndExecuteTransaction parameters
       1.1. `signerAccountId` : `String` - Hedera account id in the format `<network>:<shard>.<realm>.<num><-optional-checksum>`
-  ```
-      1.2. `transactionList` : `String` - base64 encoded string of TransactionList bytes
+      1.2. `transactionList` : `String` - Base64 encoded string of TransactionList bytes
 
 ### Returns
 
@@ -57,7 +54,7 @@ Wallets and SDKs must take special care to deserialize the list of transactions 
 In certain conditions, the Hedera network will return a response that signifies a pre-processing validation error, for example, when the transaction has expired. In these cases, wallets will return an error with the following format:
 
     1. `Object` - Result of transaction submission to Hedera network
-      1.1. `code` : 9000 - the reserved Wallet Connect error code for unknown or errors not related to the Wallet Connect protocol
+      1.1. `code` : 9000 - The reserved WalletConnect error code for unknown errors or errors not related to the WalletConnect protocol
       1.2. `message` : `String` - A human readable string describing the nature of the failure
       1.3. `data` : `Number` - An integer representing the ResponseCodeEnum value returned from the Hedera Node, which indicates the reason for the failure
 
@@ -76,7 +73,6 @@ In certain conditions, the Hedera network will return a response that signifies 
   }
 }
 ```
-
 #### Result
 ```json
 {
@@ -89,7 +85,6 @@ In certain conditions, the Hedera network will return a response that signifies 
   }
 }
 ```
-
 #### Error
 ```json
 {
@@ -109,13 +104,13 @@ The `hedera_signTransaction` signs a `TransactionBody` and returns a `SignatureM
 ### Parameters
 
     1. `Object` - signTransaction parameters
-      1.1 `signerAccountId` : `String` - hedera account id in the format `<network>:<shard>.<realm>.<num><-optional-checksum>`
-      1.2 `transactionBody` : `String` - base64 encoded string representation of TransactionBody 
+      1.1 `signerAccountId` : `String` - Hedera account id in the format `<network>:<shard>.<realm>.<num><-optional-checksum>`
+      1.2 `transactionBody` : `String` - Base64 encoded string representation of TransactionBody
 
 ### Returns
 
-    1. `Object` - signTransaction parameters
-      1.1 `signatureMap` : `String` - base64 encoded string of SignatureMap
+    1. `Object` - SignatureMap of related signed TransactionBody
+      1.1 `signatureMap` : `String` - Base64 encoded string of SignatureMap
 
 ### Example
 
@@ -147,12 +142,12 @@ When a dApp only requires the services of the controller to act as a relay to th
 
 ### Parameters
 
-    1. `Object` - signMessage parameters
-      1.1 `transactionList` : `String` base64 encoded TransactionList
+    1. `Object` - executeTransaction parameters
+      1.1 `transactionList` : `String` Base64 encoded TransactionList
 
 ### Returns
 
-    1. `Object` - Result of transaction submission to Hedera network
+    1. `Object` - Result of transaction submission to the Hedera network
       1.1. `nodeId` : `String` - The Hedera node the transaction was submitted to
       1.1. `transactionHash` : `String` - The hash of the transaction
       1.1. `transactionId` : `String` - Transaction ID, which includes the payer account id and the valid start timestamp
@@ -161,8 +156,8 @@ When a dApp only requires the services of the controller to act as a relay to th
 
 In certain conditions, the Hedera network with return a response that signifies a pre-processing validation error, for example, when the transaction has expired. In these cases, wallets will return an error with the following format:
 
-    1. `Object` - Result of transaction submission to Hedera network
-      1.1. `code` : 9000 - the reserved Wallet Connect error code for unknown or errors not related to the Wallet Connect protocol
+    1. `Object` - Result of transaction submission to the Hedera network
+      1.1. `code` : 9000 - The reserved WalletConnect error code for unknown errors or errors not related to the WalletConnect protocol
       1.1. `message` : `String` - A human readable string describing the nature of the failure
       1.1. `data` : `Number` - An integer representing the ResponseCodeEnum value returned from the Hedera Node, which indicates the reason for the failure
 
@@ -206,19 +201,20 @@ In certain conditions, the Hedera network with return a response that signifies 
 ```
 ## hedera\_signAndExecuteQuery
 
-This method provides functionality to perform a query on a Hedera consensus node. Many Queries against consensus nodes have a transaction fee [Learn more about Queries](https://docs.hedera.com/hedera/sdks-and-apis/sdks/queries)
-Most request that do not change network state can be performed against a [Mirror Node](https://docs.hedera.com/hedera/core-concepts/mirror-nodes) and for many use cases calling a mirror node endpoint is the recommended approach.
+This method provides functionality to perform a query on a Hedera consensus node. Many Queries against consensus nodes have a transaction fee [Learn more about Queries](https://docs.hedera.com/hedera/sdks-and-apis/sdks/queries).
+
+Most requests that do not change network state can be performed against a [Mirror Node](https://docs.hedera.com/hedera/core-concepts/mirror-nodes) and for many use cases calling a mirror node endpoint is the recommended approach.
 
 ### Parameters
 
-    1. `Object` - signMessage parameters
+    1. `Object` - signAndExecuteQuery parameters
       1.1 `signerAccountId` : `String` - Hedera account id in the format `<network>:<shard>.<realm>.<num><-optional-checksum>`
-      1.2 `query` : `String` base64 encoded Query
+      1.2 `query` : `String` - base64 encoded Query
 
 ### Returns
 
-    1. `Object` - Result of Query to Hedera consensus node
-      1.1. `response` : `String` - base64 encoding of Hedera API response
+    1. `Object` - Result of the Query submitteed to a Hedera consensus node
+      1.1. `response` : `String` - Base64 encoding of the Hedera API response
 
 
 ## hedera\_signMessage
@@ -226,20 +222,19 @@ Most request that do not change network state can be performed against a [Mirror
 This method accepts a plain text string value as input. If approved by the user, the controller UTF-8 encodes this message prepended with "\x19Hedera Signed Message:\n" plus the length of the message and signs the resulting bytes in the same manner as HAPI transactions are signed. The resulting signature(s) are transmitted back to the user encoded in a SignatureMap structure. The pseudo code for computing the signature is as follows:
 
 ```javascript
-
 <Ed25519 or ECDSA Key>.sign("\x19Hedera Signed Message:\n" + len(message) + message)
 ```
 
 ### Parameters
 
     1. `Object` - signMessage parameters
-      1.1 `signerAccountId` : `String` - hedera account id in the format `<network>:<shard>.<realm>.<num><-optional-checksum>`
+      1.1 `signerAccountId` : `String` - Hedera account id in the format `<network>:<shard>.<realm>.<num><-optional-checksum>`
       1.2 `message` : `String`
 
 ### Returns
 
     1. `Object` - signMessage result
-      1.1 `signatureMap` : `String` - base64 encoded SignatureMap
+      1.1 `signatureMap` : `String` - Base64 encoded SignatureMap
 
 ### Example
 
@@ -271,7 +266,7 @@ This method accepts a plain text string value as input. If approved by the user,
 
 ## hedera\_getNodeAddresses
 
-While constructing a transaction for transmission to a controller, a dApp needs to choose which Hedera Network node shall receive the transaction prior to signing (this is a requirement of the Hedera API Protocol). While a dApp can easily obtain a list of potential Hedera Nodes, a controller may not have an all-inclusive list nor a path to the node’s gRPC endpoint. The hedera_getNodeAddresses method allows a dApp to request a list of node wallet addresses known to the controller. The controller should only include nodes in this list that it is willing and able to submit transactions to at the time of the request.
+While constructing a transaction for transmission to a controller, a dApp needs to choose which Hedera Network node shall receive the transaction prior to signing (this is a requirement of the Hedera API Protocol). While a dApp can easily obtain a list of potential Hedera Nodes, a controller may not have an all-inclusive list nor a path to the node’s gRPC endpoint. The `hedera_getNodeAddresses` method allows a dApp to request a list of node wallet addresses known to the controller. The controller should only include nodes in this list that it is willing and able to submit transactions to at the time of the request.
 
 ### Returns
 
@@ -297,7 +292,7 @@ While constructing a transaction for transmission to a controller, a dApp needs 
   "id": 1,
   "jsonrpc": "2.0",
   "result": {
-    "nodes": ["hedera:testnet:0.0.3", "hedera:testnet:0.0.4"]
+    "nodes": ["0.0.3", "0.0.4"]
   }
 }
 ```


### PR DESCRIPTION
This PR fixes some inconsistency errors and typos on the Hedera spec page. This does **not** change the spec

<img width="1196" alt="Screenshot 2023-12-20 at 12 43 53 PM" src="https://github.com/WalletConnect/walletconnect-specs/assets/105378986/d13cf7cf-2a65-421b-9602-4b42153f380d">
<img width="1212" alt="Screenshot 2023-12-20 at 12 44 05 PM" src="https://github.com/WalletConnect/walletconnect-specs/assets/105378986/7003d72d-56f5-4f42-bb2f-59cb086ae58d">
