### PR TITLE
fix: add sequence number of subscriptions revision

### DIFF
--- a/docs/specs/clients/notify/authentication.md
+++ b/docs/specs/clients/notify/authentication.md
@@ -40,6 +40,7 @@ A non-ideal way to avoid the race condition is for the sender to set the message
 - iss - did:key of Notify Server authentication key
 - aud - did:key of client identity key
 - sbs - array of [Notify Server Subscriptions](./data-structures.md#notify-server-subscriptions)
+- seq - sequence number of subscription list
 
 ## wc_notifySubscriptionsChanged request
 
@@ -47,6 +48,7 @@ A non-ideal way to avoid the race condition is for the sender to set the message
 - iss - did:key of Notify Server authentication key
 - aud - did:key of client identity key
 - sbs - array of [Notify Server Subscriptions](./data-structures.md#notify-server-subscriptions)
+- seq - sequence number of subscription list
 
 ## wc_notifySubscriptionsChanged response
 
@@ -73,6 +75,7 @@ A non-ideal way to avoid the race condition is for the sender to set the message
 - app - did:web of app domain that this request is associated with 
   - Example: `did:web:app.example.com`
 - sbs - array of [Notify Server Subscriptions](./data-structures.md#notify-server-subscriptions)
+- seq - sequence number of subscription list
 
 ## wc_notifyMessage request
 
@@ -109,6 +112,7 @@ A non-ideal way to avoid the race condition is for the sender to set the message
 - app - did:web of app domain that this request is associated with 
   - Example: `did:web:app.example.com`
 - sbs - array of [Notify Server Subscriptions](./data-structures.md#notify-server-subscriptions)
+- seq - sequence number of subscription list
 
 ## wc_notifyDelete request
 
@@ -127,3 +131,4 @@ A non-ideal way to avoid the race condition is for the sender to set the message
 - app - did:web of app domain that this request is associated with 
   - Example: `did:web:app.example.com`
 - sbs - array of [Notify Server Subscriptions](./data-structures.md#notify-server-subscriptions)
+- seq - sequence number of subscription list


### PR DESCRIPTION
[Context](https://walletconnect.slack.com/archives/C044SKFKELR/p1703322752337749)

## Problem 

There is a race condition if multiple subscription updates happen at the same time that a client will receive them out-of-order and display an outdated version.

## Solution

Notify Server will now store a version for the subscriptions list. I.e. everytime a subscription is updated (in a way that would trigger subscriptions changed e.g. a subscribe, update, or delete), then this sequence number will also be incremented.

The sequence number is sent to the account alongside the list of subscriptions which clients will then store with their local list of subscriptions. Whenever the client processes a `sbs` value it is to first check the sequence number, and if it is smaller than the current number then it is to disregard the update.