### PR TITLE
Add image urls scopes

### DIFF
--- a/docs/specs/clients/notify/client-sdk-api.md
+++ b/docs/specs/clients/notify/client-sdk-api.md
@@ -30,7 +30,7 @@ abstract class Client {
   // query notification types available for a dapp domain
   public abstract getNotificationTypes(params: {
     appDomain: string,
-  }): Promise<NotifyAvailableTypes>
+  }): Promise<Record<string, NotifyNotificationType>>
 
   // query all active subscriptions
   public abstract getActiveSubscriptions(params: {

--- a/docs/specs/clients/notify/data-structures.md
+++ b/docs/specs/clients/notify/data-structures.md
@@ -12,15 +12,15 @@
   },
   "metadata": Metadata,
   "scope": Record<string, {
-	"description": string, 
-	"id": string
-	"enabled": boolean,
-	"name": string,
-	"imageUrls": {
-	  "sm": string,
-	  "md": string,
-	  "lg": string,
-	}
+    "description": string, 
+    "id": string
+    "enabled": boolean,
+    "name": string,
+    "imageUrls": {
+      "sm": string,
+      "md": string,
+      "lg": string,
+    }
   }>,
   "expiry": number,
 }

--- a/docs/specs/clients/notify/data-structures.md
+++ b/docs/specs/clients/notify/data-structures.md
@@ -11,17 +11,7 @@
     "data": string
   },
   "metadata": Metadata,
-  "scope": Record<string, {
-    "description": string, 
-    "id": string,
-    "enabled": boolean,
-    "name": string,
-    "imageUrls": {
-      "sm": string,
-      "md": string,
-      "lg": string,
-    }
-  }>,
+  "scope": Record<string, NotifyNotificationType>,
   "expiry": number,
 }
 ```
@@ -81,3 +71,20 @@ NotifyServerSubscription[]
 }
 
 ```
+
+## Notify Notification Type
+`NotifyNotificationType`
+```typescript
+{
+  "description": string, 
+  "id": string,
+  "enabled": boolean,
+  "name": string,
+  "imageUrls": {
+    "sm": string,
+    "md": string,
+    "lg": string,
+  }
+}
+```
+

--- a/docs/specs/clients/notify/data-structures.md
+++ b/docs/specs/clients/notify/data-structures.md
@@ -13,6 +13,7 @@
   "metadata": Metadata,
   "scope": Record<string, {
 	"description": string, 
+	"id": string
 	"enabled": boolean,
 	"name": string,
 	"imageUrls": {

--- a/docs/specs/clients/notify/data-structures.md
+++ b/docs/specs/clients/notify/data-structures.md
@@ -9,9 +9,18 @@
   "relay": {
     "protocol": string,
     "data": string
-  },  
+  },
   "metadata": Metadata,
-  "scope": Record<string, {description: string, enabled: boolean}>,
+  "scope": Record<string, {
+	"description": string, 
+	"enabled": boolean,
+	"name": string,
+	"imageUrls": {
+	  "sm": string,
+	  "md": string,
+	  "lg": string,
+	}
+  }>,
   "expiry": number,
 }
 ```

--- a/docs/specs/clients/notify/data-structures.md
+++ b/docs/specs/clients/notify/data-structures.md
@@ -13,7 +13,7 @@
   "metadata": Metadata,
   "scope": Record<string, {
     "description": string, 
-    "id": string
+    "id": string,
     "enabled": boolean,
     "name": string,
     "imageUrls": {


### PR DESCRIPTION
- Add imageUrls to scopes as we want to use images from notification types, nor from the `icon` property of notifications
- Add `id` and `name` since they are already implemented