### PR TITLE
feat: onramp pay sdk URL generator spec

### DIFF
--- a/docs/specs/servers/blockchain/blockchain-server-api.md
+++ b/docs/specs/servers/blockchain/blockchain-server-api.md
@@ -138,14 +138,12 @@ The POST request body should be in JSON format with the following structure:
 ```
 
 * `destinationWallets` - array of objects which define blockchain types (blockchains) and destination addresses (address):
-
     * `address` - destination address where the purchased tokens will be sent.
     * `blockchains` - (Optional) list of string blockchains enabled for the associated address.
     * `assets` - (Optional) list of string assets enabled for the associated address.
     * `supportedNetworks` - (Optional) list of strings with restricted networks available for the associated assets.
-
 * `partnerUserId` - unique ID representing the client app user. Must be less than 50 chars.
-* `defaultNetwork` - (Optional) default network that should be selected when multiple networks are present.
+* `defaultNetwork` - (Optional) default network as [CAIP10](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md) that should be selected when multiple networks are present e.g. `EIP155:1` for Ethereum.
 * `presetCryptoAmount` - (Optional) preset crypto amount value.
 * `presetFiatAmount` - (Optional) preset fiat amount value (for USD, CAD, GBP, EUR only). Ignored if `presetCryptoAmount` is set.
 * `defaultExperience` - (Optional) default visual experience: either transfer funds from Coinbase `send` or buy assets `buy`.

--- a/docs/specs/servers/blockchain/blockchain-server-api.md
+++ b/docs/specs/servers/blockchain/blockchain-server-api.md
@@ -110,3 +110,52 @@ Used to lookup for suggestions for the new name by returning 3 unique usernames.
 ```
 
 * `suggestions` - suggested profile names.
+
+## Generators
+
+### Pay SDK URL
+
+This endpoint is used to generate the On Ramp Pay SDK URL.
+
+`POST /v1/generators/onrampurl?projectID={projectID}`
+
+* `projectID` - is the project identifier
+
+#### Request body:
+
+The POST request body should be in JSON format with the following structure:
+
+```typescript
+{
+    "destinationWallets": object[],
+    "partnerUserId": string,
+    "defaultNetwork": (optional) string,
+    "presetCryptoAmount": (optional) number,
+    "presetFiatAmount": (optional) number,
+    "defaultExperience": (optional) "send" | "buy",
+    "handlingRequestedUrls": (optional) bool
+}
+```
+
+* `destinationWallets` - array of objects which define blockchain types (blockchains) and destination addresses (address):
+
+    * `address` - destination address where the purchased tokens will be sent.
+    * `blockchains` - (Optional) list of string blockchains enabled for the associated address.
+    * `assets` - (Optional) list of string assets enabled for the associated address.
+    * `supportedNetworks` - (Optional) list of strings with restricted networks available for the associated assets.
+
+* `partnerUserId` - unique ID representing the client app user. Must be less than 50 chars.
+* `defaultNetwork` - (Optional) default network that should be selected when multiple networks are present.
+* `presetCryptoAmount` - (Optional) preset crypto amount value.
+* `presetFiatAmount` - (Optional) preset fiat amount value (for USD, CAD, GBP, EUR only). Ignored if `presetCryptoAmount` is set.
+* `defaultExperience` - (Optional) default visual experience: either transfer funds from Coinbase `send` or buy assets `buy`.
+* `handlingRequestedUrls` - (Optional) prevents the widget from opening URLs directly.
+
+#### Success response body:
+
+* `url` - generated URL for the On Ramp Pay SDK.
+
+#### Response error codes:
+
+* `400 Bad Request` - some parameters in request body were missed or wrong.
+* `401 Unauthorized` - projectID verification error.


### PR DESCRIPTION
This PR introduces the SPEC for the new blockchain-api endpoint for the Coinbase On Ramp Pay SDK URL generator.
 * New proposed endpoint: `/v1/generators/onrampurl`
 * Input parameters are according to the [generateOnRampURL](https://docs.cloud.coinbase.com/pay-sdk/docs/generating-url#generateonrampurl-parameters) serialized in JSON and using the `POST` method.

The implementation in the blockchain-api: https://github.com/WalletConnect/blockchain-api/pull/453