### PR TITLE
fix: newline formatting

### DIFF
--- a/docs/specs/clients/core/crypto/crypto-envelopes.md
+++ b/docs/specs/clients/core/crypto/crypto-envelopes.md
@@ -5,7 +5,10 @@ Typed envelopes purpose is to provide flexible and future proof jsonrpc serializ
 ## Envelope Structure:
 
 First byte of any serialized envelope string always defines its type so envelope structure is known:  
+
+```
 tp - type byte (1 byte)
+```
 
 ### Type 0 Envelope
 
@@ -13,15 +16,19 @@ Used when peers agreed on symmetric key and both are able to seal and open the s
 
 algo: ChaCha20-Poly1305
 
+```
 tp - type byte (1 byte) = 0
 iv - initialization vector (12 bytes)
 ct - ciphertext (N bytes)
 tag - authentication tag (16 bytes)
 sb - sealbox: ct + tag
+```
 
 #### Serialized Envelope:
 
+```
 tp + iv + sb
+```
 
 ### Type 1 Envelope
 
@@ -29,13 +36,17 @@ Used by client that is able to seal the message but it's peer is unable to open 
 
 algo: ChaCha20-Poly1305
 
+```
 tp - type byte (1 byte) = 1
 pk - public key (32 bytes)
 iv - initialization vector (12 bytes)
 ct - ciphertext (N bytes)
 tag - authentication tag (16 bytes)
 sb - sealbox: ct + tag
+```
 
 #### Serialized Type 1 Envelope:
 
+```
 tp + pk + iv + sb
+```


### PR DESCRIPTION
Newlines were ignored because it's markdown. Wrapping in code block so easier to read.