### PR TITLE
feat(ens): using the ENSIP-11 compatible lookup responses

### DIFF
--- a/docs/specs/servers/blockchain/blockchain-server-api.md
+++ b/docs/specs/servers/blockchain/blockchain-server-api.md
@@ -35,11 +35,10 @@ Used to lookup address for the name.
 * `name` - registered account name.
 * `registered` - unix time stamp of the name registration.
 * `updated` - unix time stamp  of the last name data update.
-* `addresses` - list of objects with name addresses data:
-    * `blockchain` - blockchain of the address. e.g. `eip155` for the Ethereum.
-    * `chain_id` - chain ID of the address. Can be NULL for the mainnet.
-    * `address` - address according to the blockchain format.
-    * `created` - unix time stamp when the address was added.
+* `addresses` - registered addresses for the name:
+    * `coin type` - map where the key is the [ENSIP-11](https://alpha-docs.ens.domains/ensip/11) coin type:
+        * `address` - address according to the blockchain format.
+        * `created` - unix time stamp when the address was added.
 * `attributes` - key value object of the name attributes:
     * `avatar` - (Optional) avatar url.
     * `bio` - (Optional) account profile self description.
@@ -59,11 +58,9 @@ Lookup registered account name for the address in all chains:
 
 Or the lookup for account name by the address in a specified chain:
 
-`GET /v1/profile/reverse/{blockchain}/{address}`
+`GET /v1/profile/reverse/{coin_type}/{address}`
 
-* `blockchain` - the blockchain name where lookup for the registered address and name.
-* The list of currenlty supported blockchains:
-    * `eip155` - Ethereum mainnet
+* `coin_type` - [ENSIP-11](https://alpha-docs.ens.domains/ensip/11) coin type for the registered address and name.
 * `address` - is the address for lookup. eg. `0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb`
 
 #### Success response body:
@@ -81,11 +78,10 @@ Or the lookup for account name by the address in a specified chain:
 * `name` - registered account name.
 * `registered` - unix time stamp of the name registration.
 * `updated` - unix time stamp  of the last name data update.
-* `addresses` - list of objects with name addresses data:
-    * `blockchain` - blockchain of the address. e.g. `eip155` for the Ethereum.
-    * `chain_id` - chain ID of the address. Can be NULL for the mainnet.
-    * `address` - address according to the blockchain format.
-    * `created` - unix time stamp when the address was added.
+* `addresses` - registered addresses for the name:
+    * `coin_type` - map where the key is the [ENSIP-11](https://alpha-docs.ens.domains/ensip/11) coin type:
+        * `address` - address according to the blockchain format.
+        * `created` - unix time stamp when the address was added.
 * `attributes` - key value object of the name attributes:
     * `avatar` - (Optional) avatar url.
     * `bio` - (Optional) account profile self description.


### PR DESCRIPTION
This PR changes the ENS Gateway lookup responses to the [ENSIP-11](https://alpha-docs.ens.domains/ensip/11) compatible according to the ENS discussion. This should make it easier to hook everything up on the smart contract side.
The new lookup response will look like this:
```
{
  "name": "maxim.connect.id",
  "registered_at": "2024-01-23T18:50:02.083933Z",
  "updated_at": "2024-01-23T18:50:02.083933Z",
  "attributes": {
    "bio": "im a test"
  },
  "addresses": {
    "60": { // SLIP-44 and ENSIP-11 compatible coin type. 60 - Ethereum Mainnet
        "address": "0xAff392551773CCb2574fAE23195CC3aFDBe98d18",
        "created_at": "2024-01-23T18:50:02.083933Z"
    }
  }
}
```

The gateway implementation: [#489](https://github.com/WalletConnect/blockchain-api/pull/489)