### PR TITLE
chore: update to a desirable client api

### DIFF
--- a/docs/specs/clients/notify/client-sdk-api.md
+++ b/docs/specs/clients/notify/client-sdk-api.md
@@ -57,7 +57,7 @@ abstract class Client {
   public abstract markNotificationsAsRead(params: {
     topic: string,
     notificationIds: string[],
-	all?: boolean
+    all?: boolean
   }): Promise<NotifyNotificationRecord>
 
   // delete active subscription

--- a/docs/specs/clients/notify/client-sdk-api.md
+++ b/docs/specs/clients/notify/client-sdk-api.md
@@ -51,22 +51,14 @@ abstract class Client {
     hasMoreUnread: boolean,
   }>
 
-  // get notification by ID
-  public abstract getNotification(params: {
-    topic: string,
-    id: string,
-  }): Promise<NotifyNotificationRecord>
-
   // mark notification as read
+  // if `all` is marked as true, 
+  // the array of IDs is ignored and all notifications are marked as read
   public abstract markNotificationsAsRead(params: {
     topic: string,
-    ids: string[],
+    notificationIds: string[],
+	all?: boolean
   }): Promise<NotifyNotificationRecord>
-
-  // returns how many notifications are unread
-  public abstract getUnreadNotificationsCount(params: {
-    topic: string,
-  }): Promise<number>
 
   // delete active subscription
   public abstract deleteSubscription(params: {
@@ -131,7 +123,7 @@ abstract class Client {
   public abstract on("notify_notification", (notification: NotifyNotificationRecord, metadata: Metadata) => {}): void;
 
   // Listen for when an existing notification has been changed
-  public abstract on("notify_notification_changed", (notification: NotifyNotificationRecord, metadata: Metadata) => {}): void;
+  public abstract on("notify_notifications_changed", (notifications: Record<string, { read: boolean }>) => {}): void;
 
   // for wallet to listen for result of notify subscription update
   public abstract on("notify_update", (result: NotifySubscription | Error) => {}): void;

--- a/docs/specs/clients/notify/client-sdk-api.md
+++ b/docs/specs/clients/notify/client-sdk-api.md
@@ -54,7 +54,7 @@ abstract class Client {
   // mark notification as read
   // returns true if operation was a success. 
   // For now, `read` can only be true. 
-  public abstract updateNotificationReadState(params: {
+  public abstract updateNotificationsReadState(params: {
     topic: string,
     notificationIds: string[],
 	read?: true

--- a/docs/specs/clients/notify/client-sdk-api.md
+++ b/docs/specs/clients/notify/client-sdk-api.md
@@ -52,10 +52,13 @@ abstract class Client {
   }>
 
   // mark notification as read
-  public abstract markNotificationsAsRead(params: {
+  // returns true if operation was a success. 
+  // For now, `read` can only be true. 
+  public abstract updateNotificationReadState(params: {
     topic: string,
     notificationIds: string[],
-  }): Promise<NotifyNotificationRecord>
+	read?: true
+  }): Promise<boolean>
 
   // delete active subscription
   public abstract deleteSubscription(params: {

--- a/docs/specs/clients/notify/client-sdk-api.md
+++ b/docs/specs/clients/notify/client-sdk-api.md
@@ -52,12 +52,9 @@ abstract class Client {
   }>
 
   // mark notification as read
-  // if `all` is marked as true, 
-  // the array of IDs is ignored and all notifications are marked as read
   public abstract markNotificationsAsRead(params: {
     topic: string,
     notificationIds: string[],
-    all?: boolean
   }): Promise<NotifyNotificationRecord>
 
   // delete active subscription

--- a/docs/specs/clients/notify/client-sdk-api.md
+++ b/docs/specs/clients/notify/client-sdk-api.md
@@ -57,7 +57,7 @@ abstract class Client {
   public abstract updateNotificationsReadState(params: {
     topic: string,
     notificationIds: string[],
-	read?: true
+    read?: true
   }): Promise<boolean>
 
   // delete active subscription

--- a/docs/specs/clients/notify/data-structures.md
+++ b/docs/specs/clients/notify/data-structures.md
@@ -13,6 +13,7 @@
   "metadata": Metadata,
   "scope": Record<string, {description: string, enabled: boolean}>,
   "expiry": number,
+  "unreadNotificationCount": number
 }
 ```
 
@@ -65,6 +66,7 @@ NotifyServerSubscription[]
   account: Account, // CAIP-10 account
   scope: string[], // Array of notification types enabled for this subscription
   expiry: number, // Unix timestamp of expiration
+  unreadCount: number
 }
 ```
 


### PR DESCRIPTION
- remove `getUnreadCount` as it would be redundant since we should supply in read count in get subscriptions call 
- simplify `notificiations_changed_event` so it can be easily used for diffing state cached by the client or user of the sdk
- add `unreadCount` to subscriptions
- Remove `getNotification` as it would be redundant. If someone wanted to display details of a selected notification, they can retrieve it from the existing list of notifications