### PR TITLE
fix: update Solana CAIP-2 chainId reference

### DIFF
--- a/docs/specs/clients/sign/namespaces.md
+++ b/docs/specs/clients/sign/namespaces.md
@@ -34,7 +34,7 @@ The proposal namespace is what the dapp sends to the wallet and contains the cha
     },
     "solana": {
       "methods": ["solana_signTransaction", "solana_signMessage"],
-      "chains": ["solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ"],
+      "chains": ["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],
       "events": []
     },
     "polkadot": {

--- a/docs/specs/meta-clients/web3modal/api.md
+++ b/docs/specs/meta-clients/web3modal/api.md
@@ -33,7 +33,7 @@ interface UrlQueryParams {
   search?: string; // eg. MetaMa...
   include?: string; // eg. id1,id2,id3
   exclude?: string; // eg. id1,id2,id3
-  chains?: string; // eg. eip155:1,solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ
+  chains?: string; // eg. eip155:1,solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp
   platform?: "ios" | "android";
 }
 


### PR DESCRIPTION
## Context

* The CAIP-2 standard for Solana was fixed after-the-fact to contain the correct genesis hashes for each chain: https://github.com/ChainAgnostic/namespaces/blob/main/solana%2Fcaip2.md#test-cases
* Our documentation and sample code references need to be adjusted to the canonical hashes/chainIds.