### PR TITLE
fix(blockchain-api): correct CAIP links and capitals in the list

### DIFF
--- a/docs/specs/servers/blockchain/blockchain-server-api.md
+++ b/docs/specs/servers/blockchain/blockchain-server-api.md
@@ -18,8 +18,8 @@ Used to lookup address for the name.
 
 `GET /v1/profile/account/{name}`
 
-* `name` - is the registered name. eg. `coolname.connect.id`
-    * Case insensitive alphabetic characters (a-z), numeric characters (0-9), the minus sign (-) and the period (.)
+* `name` - The registered name. eg. `coolname.connect.id`
+    * Case insensitive alphabetic characters (a-z), numeric characters (0-9), the minus sign (-) and the period (.).
     * Max 255 characters length.
 
 #### Success response body:
@@ -34,21 +34,21 @@ Used to lookup address for the name.
 }
 ```
 
-* `name` - registered account name.
-* `registered` - unix time stamp of the name registration.
-* `updated` - unix time stamp  of the last name data update.
-* `addresses` - registered addresses for the name:
-    * `coin type` - map where the key is the [ENSIP-11](https://alpha-docs.ens.domains/ensip/11) coin type:
-        * `address` - address according to the blockchain format.
-        * `created` - unix time stamp when the address was added.
-* `attributes` - key value object of the name attributes:
+* `name` - Registered account name.
+* `registered` - Unix time stamp of the name registration.
+* `updated` - Unix time stamp  of the last name data update.
+* `addresses` - Registered addresses for the name:
+    * `coin type` - Map where the key is the [ENSIP-11](https://alpha-docs.ens.domains/ensip/11) coin type:
+        * `address` - Address according to the blockchain format.
+        * `created` - Unix time stamp when the address was added.
+* `attributes` - Key value object of the name attributes:
     * `avatar` - (Optional) avatar url.
     * `bio` - (Optional) account profile self description.
 
 #### Response error codes:
 
-* `400 Bad request` - wrong requested name format.
-* `404 Not Found` - the requested name is not registered.
+* `400 Bad request` - Wrong requested name format.
+* `404 Not Found` - The requested name is not registered.
 
 ### Reverse name lookup
 
@@ -56,14 +56,14 @@ Lookup registered account name for the address in all chains:
 
 `GET /v1/profile/reverse/{address}`
 
-* `address` - is the address for lookup in all chains. eg. `0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb`
+* `address` - The address for lookup in all chains. eg. `0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb`
 
 Or the lookup for account name by the address in a specified chain:
 
 `GET /v1/profile/reverse/{coin_type}/{address}`
 
 * `coin_type` - [ENSIP-11](https://alpha-docs.ens.domains/ensip/11) coin type for the registered address and name.
-* `address` - is the address for lookup. eg. `0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb`
+* `address` - Ihe address for lookup. eg. `0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb`
 
 #### Success response body:
 
@@ -77,21 +77,21 @@ Or the lookup for account name by the address in a specified chain:
 }
 ```
 
-* `name` - registered account name.
-* `registered` - unix time stamp of the name registration.
-* `updated` - unix time stamp  of the last name data update.
-* `addresses` - registered addresses for the name:
-    * `coin_type` - map where the key is the [ENSIP-11](https://alpha-docs.ens.domains/ensip/11) coin type:
-        * `address` - address according to the blockchain format.
-        * `created` - unix time stamp when the address was added.
-* `attributes` - key value object of the name attributes:
+* `name` - Registered account name.
+* `registered` - Unix time stamp of the name registration.
+* `updated` - Unix time stamp  of the last name data update.
+* `addresses` - Registered addresses for the name:
+    * `coin_type` - Map where the key is the [ENSIP-11](https://alpha-docs.ens.domains/ensip/11) coin type:
+        * `address` - Address according to the blockchain format.
+        * `created` - Unix time stamp when the address was added.
+* `attributes` - Key value object of the name attributes:
     * `avatar` - (Optional) avatar url.
     * `bio` - (Optional) account profile self description.
 
 #### Response error codes:
 
-* `400 Bad Request` - wrong requested address format.
-* `404 Not Found` - the requested address is not registered for any name or for the specified chain.
+* `400 Bad Request` - Wrong requested address format.
+* `404 Not Found` - The requested address is not registered for any name or for the specified chain.
 
 ### Name suggestion
 
@@ -107,7 +107,7 @@ Used to lookup for suggestions for the new name by returning 3 unique usernames.
 }
 ```
 
-* `suggestions` - suggested profile names.
+* `suggestions` - Suggested profile names.
 
 ### Register the name
 
@@ -135,7 +135,7 @@ The POST request body should be in JSON format with the folowing structure:
     * `attributes` - (Optional) key value object of the name attributes:
         * `avatar` - (Optional) avatar url.
         * `bio` - (Optional) account profile self description.
-    * `timestamp` - current unixtime timestamp. The signature is valid for 10 seconds.
+    * `timestamp` - Current unixtime timestamp. The signature is valid for 10 seconds.
 * `coin_type` - Coin type according to [ENSIP-11](https://docs.ens.domains/ens-improvement-proposals/ensip-11-evmchain-address-resolution) format.
 * `signature` - Ethereum signature for the signed `message` to check the address ownership.
 * `address` - Address that bind to the account name.
@@ -143,12 +143,12 @@ The POST request body should be in JSON format with the folowing structure:
 
 #### Success response codes:
 
-* `200 Ok` - account name is successfully registered.
+* `200 Ok` - Account name is successfully registered.
 
 #### Response error codes:
 
-* `400 Bad Request` - some parameters in request body were missed or wrong.
-* `401 Unauthorized` - signature verifying error.
+* `400 Bad Request` - Some parameters in request body were missed or wrong.
+* `401 Unauthorized` - Signature verifying error.
 
 ### Updating name attributes
 
@@ -156,7 +156,7 @@ Used to update name attributes.
 
 `POST /v1/profile/account/{name}/attributes`
 
-* `name` - is the registered name. eg. `coolname.wc.ink`
+* `name` - The registered name. eg. `coolname.wc.ink`
 
 #### Request body:
 
@@ -172,22 +172,22 @@ The POST request body should be in JSON format with the folowing structure:
 ```
 
 * `message` - JSON serialized string that should contain the following fields:
-    * `attributes` - key value object of the name attributes:
+    * `attributes` - Key value object of the name attributes:
         * `avatar` - (Optional) avatar url.
         * `bio` - (Optional) account profile self description.
-    * `timestamp` - current unixtime timestamp. The signature is valid for 10 seconds.
+    * `timestamp` - Current unixtime timestamp. The signature is valid for 10 seconds.
 * `coin_type` - Coin type according to [ENSIP-11](https://docs.ens.domains/ens-improvement-proposals/ensip-11-evmchain-address-resolution) format.
 * `signature` - Ethereum signature for the signed `message` to check the address ownership.
 * `address` - Ownership address of the name.
 
 #### Success response codes:
 
-* `200 Ok` - name attributes are successfully updated.
+* `200 Ok` - Name attributes are successfully updated.
 
 #### Response error codes:
 
-* `400 Bad Request` - some parameters in request body were missed or wrong.
-* `401 Unauthorized` - signature verification or name address ownership error.
+* `400 Bad Request` - Some parameters in request body were missed or wrong.
+* `401 Unauthorized` - Signature verification or name address ownership error.
 
 ### Updating name addresses
 
@@ -195,7 +195,7 @@ Used to update or add name addresses.
 
 `POST /v1/profile/account/{name}/address`
 
-* `name` - is the registered name. eg. `coolname.wc.ink`
+* `name` - The registered name. eg. `coolname.wc.ink`
 
 #### Request body:
 
@@ -211,24 +211,24 @@ The POST request body should be in JSON format with the folowing structure:
 ```
 
 * `message` - JSON serialized string that should contain the following fields:
-    * `coin_type` - coin type of the new address according to [ENSIP-11](https://docs.ens.domains/ens-improvement-proposals/ensip-11-evmchain-address-resolution) format.
-    * `address` - new address to bind to the account name for the `coin_type`.
-    * `timestamp` - current unixtime timestamp. The signature is valid for 10 seconds.
-* `coin_type` - coin type according to [ENSIP-11](https://docs.ens.domains/ens-improvement-proposals/ensip-11-evmchain-address-resolution) format.
+    * `coin_type` - Coin type of the new address according to [ENSIP-11](https://docs.ens.domains/ens-improvement-proposals/ensip-11-evmchain-address-resolution) format.
+    * `address` - New address to bind to the account name for the `coin_type`.
+    * `timestamp` - Current unixtime timestamp. The signature is valid for 10 seconds.
+* `coin_type` - Coin type according to [ENSIP-11](https://docs.ens.domains/ens-improvement-proposals/ensip-11-evmchain-address-resolution) format.
 * `signature` - Ethereum signature for the signed `message` to check the address ownership.
-* `address` - ownership address of the name.
+* `address` - Ownership address of the name.
 
 According to the [ENSIP-11](https://docs.ens.domains/ens-improvement-proposals/ensip-11-evmchain-address-resolution)
 only one address per `coin_type` is supported. If an address is already assigned for the `coin_type` that address will be updated.
 
 #### Success response codes:
 
-* `200 Ok` - name addresses are successfully updated.
+* `200 Ok` - Name addresses are successfully updated.
 
 #### Response error codes:
 
-* `400 Bad Request` - some parameters in request body were missed or wrong.
-* `401 Unauthorized` - signature verification or name address ownership error.
+* `400 Bad Request` - Some parameters in request body were missed or wrong.
+* `401 Unauthorized` - Signature verification or name address ownership error.
 
 ## Generators
 
@@ -238,7 +238,7 @@ This endpoint is used to generate the On Ramp Pay SDK URL.
 
 `POST /v1/generators/onrampurl?projectID={projectID}`
 
-* `projectId` - is the project identifier
+* `projectId` - The project identifier
 
 #### Request body:
 
@@ -256,13 +256,13 @@ The POST request body should be in JSON format with the following structure:
 }
 ```
 
-* `destinationWallets` - array of objects which define blockchain types (blockchains) and destination addresses (address):
-    * `address` - destination address where the purchased tokens will be sent.
+* `destinationWallets` - Array of objects which define blockchain types (blockchains) and destination addresses (address):
+    * `address` - Destination address where the purchased tokens will be sent.
     * `blockchains` - (Optional) list of string blockchains enabled for the associated address.
     * `assets` - (Optional) list of string assets enabled for the associated address.
     * `supportedNetworks` - (Optional) list of strings with restricted networks available for the associated assets.
-* `partnerUserId` - unique ID representing the client app user. Must be less than 50 chars.
-* `defaultNetwork` - (Optional) default network as [CAIP10](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md) that should be selected when multiple networks are present e.g. `EIP155:1` for Ethereum.
+* `partnerUserId` - Unique ID representing the client app user. Must be less than 50 chars.
+* `defaultNetwork` - (Optional) default network as [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) that should be selected when multiple networks are present e.g. `EIP155:1` for Ethereum.
 * `presetCryptoAmount` - (Optional) preset crypto amount value.
 * `presetFiatAmount` - (Optional) preset fiat amount value (for USD, CAD, GBP, EUR only). Ignored if `presetCryptoAmount` is set.
 * `defaultExperience` - (Optional) default visual experience: either transfer funds from Coinbase `send` or buy assets `buy`.
@@ -270,12 +270,12 @@ The POST request body should be in JSON format with the following structure:
 
 #### Success response body:
 
-* `url` - generated URL for the On Ramp Pay SDK.
+* `url` - Generated URL for the On Ramp Pay SDK.
 
 #### Response error codes:
 
-* `400 Bad Request` - some parameters in request body were missed or wrong.
-* `401 Unauthorized` - projectID verification error.
+* `400 Bad Request` - Some parameters in request body were missed or wrong.
+* `401 Unauthorized` - ProjectID verification error.
 
 ## Account 
 
@@ -287,14 +287,14 @@ Used to lookup fungible assets balances
 
 #### Path parameters
 
-* `address` - is the address for lookup. eg. `0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb`
+* `address` - The address for lookup. eg. `0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb`
 
 #### Query parameters
 
-* `projectId` - the project identifier.
-* `currency` - currency to calculate the assets value. e.g. `usd`.
+* `projectId` - The project identifier.
+* `currency` - Currency to calculate the assets value. e.g. `usd`.
     * Supported currencies: `btc`, `eth`, `usd`, `eur`, `gbp`, `aud`, `cad`, `inr`, `jpy`.
-* `chain` - (Optional) filter assets by CAIP-10 chain id. Supported chain IDs:
+* `chain` - (Optional) filter assets by CAIP-2 chain id. Supported chain IDs:
     * `eip155:1` - Ethereum
     * `eip155:5` - Goerli
     * `eip155:56` - BinanceSmartChain
@@ -315,22 +315,22 @@ Used to lookup fungible assets balances
 
 #### Success response body:
 
-* `balances` - list of address balances with the following attributes:
-    * `name` - asset name. e.g. `Ethereum`
-    * `symbol` - native asset or ERC-20 symbol. e.g. `ETH`
-    * `chainId` - CAIP-10 chain id. e.g. `eip155:1`
+* `balances` - List of address balances with the following attributes:
+    * `name` - Asset name. e.g. `Ethereum`
+    * `symbol` - Native asset or ERC-20 symbol. e.g. `ETH`
+    * `chainId` - CAIP-2 chain id. e.g. `eip155:1`
     * `address` - (Optional) token contract address. The address is null for the native token.
     * `value` - (Optional) asset value in currency calculated from the request argument.
-    * `price` - price of a single unit of the asset in currency calculated from the request argument.
-    * `quantity` - asset quantity object:
-        * `decimals` - decimal number precision of the quantity.
-        * `numeric` - numeric representation of the asset quantity.
+    * `price` - Price of a single unit of the asset in currency calculated from the request argument.
+    * `quantity` - Asset quantity object:
+        * `decimals` - Decimal number precision of the quantity.
+        * `numeric` - Numeric representation of the asset quantity.
     * `iconUrl` - URL of the asset icon.
 
 #### Response error codes:
 
-* `202 Accepted` - the data for the address is not fulfilled yet, re-trying is needed in up to 180 seconds.
-* `400 Bad request` - wrong requested arguments format.
+* `202 Accepted` - The data for the address is not fulfilled yet, re-trying is needed in up to 180 seconds.
+* `400 Bad request` - Wrong requested arguments format.
 
 ## Conversion
 
@@ -342,23 +342,23 @@ Endpoints to convert tokens.
 
 #### Path parameters
 
-* `projectId` - is the project identifier
-* `chainId` - filter by chain. CAIP-2 format. e.g. `eip155:1`
+* `projectId` - The project identifier
+* `chainId` - Filter by chain. CAIP-2 format. e.g. `eip155:1`
 
 #### Success response body:
 
-* `tokens` - list of objects which define available tokens:
-    * `name` - token name.
-    * `symbol` - token symbol.
-    * `address` - contract address of the token in CAIP-10 format.
-    * `decimals` - number of decimals for amount supported by a given token.
+* `tokens` - List of objects which define available tokens:
+    * `name` - Token name.
+    * `symbol` - Token symbol.
+    * `address` - Contract address of the token in CAIP-10 format.
+    * `decimals` - Number of decimals for amount supported by a given token.
     * `logoUri` - URL of the token icon.
     * `eip2612` - (Optional for ERC-20 tokens) value is `true` if the token supports [eip-2612](https://eips.ethereum.org/EIPS/eip-2612)
 
 #### Response error codes:
 
-* `400 Bad Request` - some parameters in request body were missed or wrong.
-* `401 Unauthorized` - project ID verification error.
+* `400 Bad Request` - Some parameters in request body were missed or wrong.
+* `401 Unauthorized` - Project ID verification error.
 
 ### Requesting conversion quotes
 
@@ -366,25 +366,25 @@ Endpoints to convert tokens.
 
 #### Path parameters
 
-* `projectId` - is the project identifier.
-* `amount` - amount of tokens to be converted related to the decimals of the token. Numeric value up to 18 decimals.
-* `userAddress` - caller address.
-* `from` - source CAIP-10 asset address.
-* `to` - destination CAIP-10 asset address.
+* `projectId` - The project identifier.
+* `amount` - Amount of tokens to be converted related to the decimals of the token. Numeric value up to 18 decimals.
+* `userAddress` - Caller address.
+* `from` - Source CAIP-10 asset address.
+* `to` - Destination CAIP-10 asset address.
 
 #### Success response body:
 
-* `quotes` - list of objects which define available conversion quotes:
+* `quotes` - List of objects which define available conversion quotes:
     * `id` - (Optional for cross chain swaps) quote ID to be used for convert request.
-    * `fromAmount` - amount of token being sent on sending chain.
-    * `fromAccount` - source CAIP-10 account ID.
-    * `toAmount` - amount of token to be received on the destination chain.
-    * `toAccount` - destination CAIP-10 account ID.
+    * `fromAmount` - Amount of token being sent on sending chain.
+    * `fromAccount` - Source CAIP-10 account ID.
+    * `toAmount` - Amount of token to be received on the destination chain.
+    * `toAccount` - Destination CAIP-10 account ID.
 
 #### Response error codes:
 
-* `400 Bad Request` - some parameters in request body were missed or wrong.
-* `401 Unauthorized` - project ID verification error.
+* `400 Bad Request` - Some parameters in request body were missed or wrong.
+* `401 Unauthorized` - Project ID verification error.
 
 ### Requesting approve calldata
 
@@ -397,8 +397,8 @@ In this case, the `permit` parameter in `Requesting calldata to convert` should 
 
 ####  Path parameters
 
-* `projectId` - is the project identifier.
-* `userAddress` - caller address.
+* `projectId` - The project identifier.
+* `userAddress` - Caller address.
 * `from` - Source CAIP-10 asset address.
 * `to` - Destination CAIP-10 asset address.
 * `amount` - Amount of tokens to be converted related to the decimals of the token.
@@ -428,10 +428,10 @@ Generate calldata for convert transaction.
 
 The `POST` request body should be in JSON format with the following structure:
 
-* `projectId` - is the project identifier.
-* `userAddress` - caller address.
-* `from` - asset source CAIP-10 address.
-* `to` - asset destination CAIP-10 address.
+* `projectId` - The project identifier.
+* `userAddress` - Caller address.
+* `from` - Asset source CAIP-10 address.
+* `to` - Asset destination CAIP-10 address.
 * `amount` - Amount of tokens to be converted denominated in the decimal precision of the token.
 * `eip155`- (Optional) For EVM converts only
     * `slippage` - Slippage integer value. Max. 50


### PR DESCRIPTION
This PR fixing typos and style correcting:
* Corrects the wrong CAIP,
* Making all capitals in lists in the blockchain-API specs.