### PR TITLE
chore: add prepare registration with recaps spec

### DIFF
--- a/docs/specs/clients/notify/client-sdk-api.md
+++ b/docs/specs/clients/notify/client-sdk-api.md
@@ -67,6 +67,20 @@ abstract class Client {
     topic: string,
     encryptedMessage: string,
   }): Promise<NotifyNotification>;
+  
+
+  // Generates and returns incomplete CacaoPayload
+  // To be handled in recaps based authentication.
+  // This enables one-click-auth based authentication to
+  // also enable permissions for notify API.
+  public abstract prepareRegistrationWithRecaps(params: {
+    domain: string;
+    allApps?: boolean;
+  }): Promise<{
+    allApps: boolean;
+	cacaoPayload: CacaoPayload
+	privateIdentityKey: string
+  }>;
 
   // Generates and returns SIWE message along with
   // Cacao Payload with identity key

--- a/docs/specs/clients/notify/client-sdk-api.md
+++ b/docs/specs/clients/notify/client-sdk-api.md
@@ -78,8 +78,8 @@ abstract class Client {
     allApps?: boolean;
   }): Promise<{
     allApps: boolean;
-	cacaoPayload: CacaoPayload
-	privateIdentityKey: string
+    cacaoPayload: CacaoPayload
+    privateIdentityKey: string
   }>;
 
   // Generates and returns SIWE message along with


### PR DESCRIPTION
Recaps support has been in the notify SDKs for a while but we have not officially specced it out yet.

Here's the spec, mimicking the current implementation on JS. 