### PR TITLE
feat: rejection tags

### DIFF
--- a/docs/specs/clients/sign/rpc-methods.md
+++ b/docs/specs/clients/sign/rpc-methods.md
@@ -61,6 +61,8 @@ Used to propose a session through topic A. Requires a success response with asso
 
 **Response**
 
+Approve
+
 ```jsonc
 // Success result
 {
@@ -75,6 +77,28 @@ Used to propose a session through topic A. Requires a success response with asso
 | ------- | -------- |
 | TTL     | 300      |
 | Tag     | 1101     |
+```
+
+Reject
+
+```jsonc
+// JsonRpc Error
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Tag     | 1120     |
+```
+
+Auto Reject
+
+```jsonc
+// JsonRpc Error
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Tag     | 1121     |
 ```
 
 #### wc_sessionSettle
@@ -410,6 +434,8 @@ When DApp is setting `expiry` params, client should insure that Relay Publish pa
 
 **Response**
 
+Approve
+
 ```ts
 // Success result (array of signed CACAOs)
 [{
@@ -422,4 +448,26 @@ When DApp is setting `expiry` params, client should insure that Relay Publish pa
 | ------- | -------- |
 | TTL     | 3600    |
 | Tag     | 1117     |
+```
+
+Reject
+
+```jsonc
+// JsonRpc Error
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Tag     | 1118     |
+```
+
+Auto Reject
+
+```jsonc
+// JsonRpc Error
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 300      |
+| Tag     | 1119     |
 ```


### PR DESCRIPTION
This PR introduces rejection tags for session proposals and authenticated session flow to include them in the connection flow success rate metric calculations.
Currently, there's no way to see rejection from the data POV, this PR enables it.