### PR TITLE
feat: adding `gasPrice` optional parameter to the convertion quote

### DIFF
--- a/docs/specs/servers/blockchain/blockchain-server-api.md
+++ b/docs/specs/servers/blockchain/blockchain-server-api.md
@@ -398,6 +398,7 @@ Endpoints to convert tokens.
 * `userAddress` - Caller address.
 * `from` - Source CAIP-10 asset address.
 * `to` - Destination CAIP-10 asset address.
+* `gasPrice` - (Optional) Network price per gas in wei. By default fast network gas price.
 
 #### Success response body:
 


### PR DESCRIPTION
This PR adds an optional `gasPrice` parameter to the conversion quote endpoint to allow the user to choose the gas type (normal, fast, etc.)