### PR TITLE
feat: verify attestation field

### DIFF
--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -10,7 +10,7 @@ The following definitions are shared concepts across all JSON-RPC methods for th
 
 - **topic** - (hex string - 32 bytes) a target topic for the message to be subscribed by the receiver.
 - **message** - (utf8 string - variable) a plaintext message to be relayed to any subscribers on the topic.
-- **attachments** - (utf8 string - variable) a plaintext message to be relayed to any subscribers on the topic. Not included in Verify API attestation.
+- **attachments** - (utf8 string - variable) a plaintext message to be relayed to any subscribers on the topic. Not included in Verify API attestation. This SHOULD be a JSON object to make adding more values easy and backwards-compatible, but its value is defined at the API level.
 - **ttl** - (uint32 - 4 bytes) a storage duration for the message to be cached server-side in **seconds** (aka time-to-live).
 - **tag** - (uint32 - 4 bytes) a label that identifies what type of message is sent based on the RPC method used.
 - **id** - 19 digit unique identifier. We suggest a 13 digit epoch timestamp plus 6 digit entropy

--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -10,7 +10,7 @@ The following definitions are shared concepts across all JSON-RPC methods for th
 
 - **topic** - (hex string - 32 bytes) a target topic for the message to be subscribed by the receiver.
 - **message** - (utf8 string - variable) a plaintext message to be relayed to any subscribers on the topic.
-- **attachments** - (utf8 string - variable) a plaintext message to be relayed to any subscribers on the topic. Not included in Verify API attestation. This SHOULD be a JSON object to make adding more values easy and backwards-compatible, but its value is defined at the API level.
+- **attestation** - (utf8 string - variable) the Verify attestation JWT to be included along with the message. Not included in Verify API attestation.
 - **ttl** - (uint32 - 4 bytes) a storage duration for the message to be cached server-side in **seconds** (aka time-to-live).
 - **tag** - (uint32 - 4 bytes) a label that identifies what type of message is sent based on the RPC method used.
 - **id** - 19 digit unique identifier. We suggest a 13 digit epoch timestamp plus 6 digit entropy
@@ -25,12 +25,12 @@ Used when a client publishes a message to a server.
 // Request (client->server)
 {
   id: string,
-  jsonrpc": "2.0",
+  jsonrpc: "2.0",
   method: "irn_publish",
   params: {
     topic: string,
     message: string,
-    attachments?: string | null,
+    attestation?: string | null,
     ttl: seconds,
     tag: number,
   }
@@ -53,7 +53,7 @@ Used when a client publishes multiple messages to a server.
 {
   topic: string,
   message: string,
-  attachments?: string | null,
+  attestation?: string | null,
   ttl: seconds,
   tag: number,
 }
@@ -191,7 +191,7 @@ Used when a server sends a subscription message to a client.
     "data" : {
       "topic": string,
       "message": string,
-      "attachments": string | null,
+      "attestation": string | null,
       "publishedAt": number,
       "tag": number
     }
@@ -376,7 +376,7 @@ Body:
     "status": string, // either "accepted", "queued" or "delivered"
     "topic": string,
     "message": string,
-    "attachments": string | null,
+    "attestation": string | null,
     "publishedAt": number,
     "tag": number
   }

--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -10,6 +10,7 @@ The following definitions are shared concepts across all JSON-RPC methods for th
 
 - **topic** - (hex string - 32 bytes) a target topic for the message to be subscribed by the receiver.
 - **message** - (utf8 string - variable) a plaintext message to be relayed to any subscribers on the topic.
+- **attachments** - (utf8 string - variable) a plaintext message to be relayed to any subscribers on the topic. Not included in Verify API attestation.
 - **ttl** - (uint32 - 4 bytes) a storage duration for the message to be cached server-side in **seconds** (aka time-to-live).
 - **tag** - (uint32 - 4 bytes) a label that identifies what type of message is sent based on the RPC method used.
 - **id** - 19 digit unique identifier. We suggest a 13 digit epoch timestamp plus 6 digit entropy
@@ -20,17 +21,18 @@ The following definitions are shared concepts across all JSON-RPC methods for th
 
 Used when a client publishes a message to a server.
 
-```jsonc
+```typescript
 // Request (client->server)
 {
-  "id" : "1",
-  "jsonrpc": "2.0",
-  "method": "irn_publish",
-  "params" : {
-    "topic" : string,
-    "message" : string,
-    "ttl" : seconds,
-    "tag" : number,
+  id: string,
+  jsonrpc": "2.0",
+  method: "irn_publish",
+  params: {
+    topic: string,
+    message: string,
+    attachments?: string | null,
+    ttl: seconds,
+    tag: number,
   }
 }
 
@@ -46,13 +48,14 @@ Used when a client publishes a message to a server.
 
 Used when a client publishes multiple messages to a server.
 
-```jsonc
+```typescript
 // PublishedMessage
 {
-  "topic" : string,
-  "message" : string,
-  "ttl" : seconds,
-  "tag" : number,
+  topic: string,
+  message: string,
+  attachments?: string | null,
+  ttl: seconds,
+  tag: number,
 }
 
 // Request (client->server)
@@ -188,6 +191,7 @@ Used when a server sends a subscription message to a client.
     "data" : {
       "topic": string,
       "message": string,
+      "attachments": string | null,
       "publishedAt": number,
       "tag": number
     }
@@ -372,6 +376,7 @@ Body:
     "status": string, // either "accepted", "queued" or "delivered"
     "topic": string,
     "message": string,
+    "attachments": string | null,
     "publishedAt": number,
     "tag": number
   }


### PR DESCRIPTION
As per the [Verify V2](https://www.notion.so/walletconnect/Verify-Server-rewrite-tech-doc-Verify-API-V2-30e207c77f8447d8af37a186799b7c9e?pvs=4#fbc0ca6d67c444118599ba49d8b358f9) technical doc, this adds the `attestation` field to the data the relay relays.