### PR TITLE
feat(sessions): permission co-signer API

### DIFF
--- a/docs/specs/servers/blockchain/blockchain-permissions-api.md
+++ b/docs/specs/servers/blockchain/blockchain-permissions-api.md
@@ -174,3 +174,51 @@ The POST request body should be in JSON format and following schema:
 
 * `400 Bad request` - Wrong format in request.
 * `401 Unauthorized` - Wrong signature.
+
+## Co-signing
+
+Co-signing request
+
+`POST /v1/sessions/{address}/sign?projectId={projectId}`
+
+* `address` - CAIP-10 address format.
+* `projectId` - Required. The project identifier.
+
+### Request body:
+
+The POST request body should be in JSON format and following schema:
+
+```typescript
+{
+	pci: String, // Permission controller identifier.
+	userOp: // ERC-4337 pseudo transaction object:
+  {
+    sender: string, // The address of the smart contract account.
+    nonce: number, // Anti-replay protection; also used as the salt for first-time account creation.
+    initCode: string, // Code used to deploy the account if not yet on-chain.
+    callData: string, // Data that's passed to the sender for execution.
+    callGasLimit: number, // Gas limit for execution phase.
+    verificationGasLimit: number, // Gas limit for verification phase.
+    preVerificationGas: number, // Gas to compensate the bundler.
+    maxFeePerGas: number, // Maximum fee per gas (similar to EIP-1559(opens in a new tab) max_fee_per_gas).
+    maxPriorityFeePerGas: number, // Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas).
+    paymasterAndData: string, // Paymaster Contract address and any extra data required for verification and execution (empty for self-sponsored transaction).
+    signature: string // Signature of all `userOp` fields hashed by keccak256 and signed by the key provided during the permission creation.
+  }
+}
+```
+
+#### Success response body:
+
+Response will contain user operation receipt.
+
+```typescript
+{
+    userOpReceipt: string // User operation receipt data.
+}
+```
+
+#### Response error codes:
+
+* `400 Bad request` - Wrong format in request.
+* `401 Unauthorized` - Wrong signature.

--- a/docs/specs/servers/blockchain/blockchain-permissions-api.md
+++ b/docs/specs/servers/blockchain/blockchain-permissions-api.md
@@ -1,0 +1,108 @@
+# Blockchain API Sessions and Permissions
+
+## Sessions permissions storage
+
+### Get permissions list
+
+Used to get account list of active sessions
+
+`GET /v1/sessions/{address}?projectId={projectId}`
+
+* `address` - CAIP-10 address format.
+* `projectId` - The project identifier.
+
+#### Success response body:
+
+```typescript
+{
+    sessions: []
+}
+```
+
+#### Response error codes:
+
+* `400 Bad request` - Wrong requested address format.
+
+## Add a new permission 
+
+Creating a new permission session for the account
+
+`POST /v1/sessions/{address}?projectId={projectId}`
+
+* `address` - CAIP-10 address format.
+* `projectId` - The project identifier.
+
+### Request body:
+
+The POST request body should be in JSON format and following schema:
+
+```typescript
+{
+  message: {
+    permission: {},
+    timestamp: string
+  },
+  signature: string,
+}
+```
+
+* `message` - Message that used in signature:
+    * `permission` - New permission object.
+    * `timestamp` - Current unixtime timestamp. The signature is valid for 10 seconds.
+* `signature` - Ethereum signature for the signed `message` to check the address ownership.
+
+#### Success response body:
+
+Response will contain an updated list of sessions for the address.
+
+```typescript
+{
+    sessions: []
+}
+```
+
+#### Response error codes:
+
+* `400 Bad request` - Wrong format in request.
+
+## Revoke permission 
+
+Revoking a permission from account sessions.
+
+`POST /v1/sessions/{address}/revoke/?projectId={projectId}`
+
+* `address` - CAIP-10 address format.
+* `projectId` - The project identifier.
+
+### Request body:
+
+The POST request body should be in JSON format and following schema:
+
+```typescript
+{
+  message: {
+    pci: string,
+    timestamp: string
+  },
+  signature: string,
+}
+```
+
+* `message` - Message that used in signature:
+    * `pci` - Unique permission context identifier.
+    * `timestamp` - Current unixtime timestamp. The signature is valid for 10 seconds.
+* `signature` - Ethereum signature for the signed `message` to check the address ownership.
+
+#### Success response body:
+
+Response will contain an updated list of sessions for the address.
+
+```typescript
+{
+    sessions: []
+}
+```
+
+#### Response error codes:
+
+* `400 Bad request` - Wrong format in request.

--- a/docs/specs/servers/blockchain/blockchain-permissions-api.md
+++ b/docs/specs/servers/blockchain/blockchain-permissions-api.md
@@ -1,5 +1,7 @@
 # Blockchain API Sessions and Permissions
 
+This API is **unstable**, not yet production ready and can be changed at any time.
+
 ## Sessions permissions storage
 
 ### Get permissions list for account
@@ -77,14 +79,17 @@ The POST request body should be in JSON format and following schema:
 
 #### Success response body:
 
-Response will contain a new generated ECDSA key and PCI of the new permission.
+Response will contain a new generated key and PCI of the new permission.
 
 ```typescript
 {
-    key: string,
-    pci: string
+    pci: string,
+    key: string
 }
 ```
+
+* `pci` - New unique permission controller identifier.
+* `key` - Generated signing (private) ECDSA P256 key in DER, SEC1 format encoded by Base64.
 
 #### Response error codes:
 
@@ -94,7 +99,7 @@ Response will contain a new generated ECDSA key and PCI of the new permission.
 
 Updating permissions context for the certain permission idenitifier.
 
-`POST /v1/sessions/{address}/context/?projectId={projectId}`
+`POST /v1/sessions/{address}/context?projectId={projectId}`
 
 * `address` - CAIP-10 address format.
 * `projectId` - Required. The project identifier.
@@ -110,7 +115,7 @@ The POST request body should be in JSON format and following schema:
     context: {
       {
         signer: {
-          type: string,
+          permissionType: string,
           ids: [string]
         },
         expiry: number,
@@ -126,22 +131,23 @@ The POST request body should be in JSON format and following schema:
 ```
 
 * `pci` - PCI to revoke.
-* `signature` - Signature signed by the key provided during the permission creation.
+* `signature` - Signature of canonicalized JSON `context` object signed by the key provided during the permission creation. The signature must be provided as DER, SEC1 and encoded in Base64 format.
 * `context` - Permissions context object to update.
 
 #### Success response body:
 
-* `202 Accepted` - Successfully updated.
+* `200 Ok` - Successfully updated.
 
 #### Response error codes:
 
 * `400 Bad request` - Wrong format in request.
+* `401 Unauthorized` - Wrong signature.
 
 ## Revoke permission 
 
 Revoking a permission from account sessions.
 
-`POST /v1/sessions/{address}/revoke/?projectId={projectId}`
+`POST /v1/sessions/{address}/revoke?projectId={projectId}`
 
 * `address` - CAIP-10 address format.
 * `projectId` - Required. The project identifier.
@@ -158,12 +164,13 @@ The POST request body should be in JSON format and following schema:
 ```
 
 * `pci` - PCI to revoke.
-* `signature` - Signature signed by the key provided during the permission creation.
+* `signature` - Signature of signed `pci` field by the key provided during the permission creation. The signature must be provided as DER, SEC1 and encoded in Base64 format.
 
 #### Success response body:
 
-* `202 Accepted` - Successfully revoked.
+* `200 Ok` - Successfully revoked.
 
 #### Response error codes:
 
 * `400 Bad request` - Wrong format in request.
+* `401 Unauthorized` - Wrong signature.

--- a/docs/specs/servers/blockchain/blockchain-permissions-api.md
+++ b/docs/specs/servers/blockchain/blockchain-permissions-api.md
@@ -91,6 +91,53 @@ Response will contain a new generated ECDSA key and PCI of the new permission.
 
 * `400 Bad request` - Wrong format in request.
 
+## Updating permissions context
+
+Updating permissions context for the certain permission idenitifier.
+
+`POST /v1/sessions/{address}/context/?projectId={projectId}`
+
+* `address` - CAIP-10 address format.
+* `projectId` - The project identifier.
+
+### Request body:
+
+The POST request body should be in JSON format and following schema:
+
+```typescript
+{
+    pci: string,
+    signature: string,
+    context: {
+      {
+        signer: {
+          type: string,
+          ids: [string]
+        },
+        expiry: number,
+        signerData: {
+          userOpBuilder: string
+        },
+        factory: string,
+        factoryData: string,
+        permissionsContext: string
+      }
+    }
+}
+```
+
+* `pci` - PCI to revoke.
+* `signature` - Signature signed by the key provided during the permission creation.
+* `context` - Permissions context object to update.
+
+#### Success response body:
+
+* `202 Accepted` - Successfully updated.
+
+#### Response error codes:
+
+* `400 Bad request` - Wrong format in request.
+
 ## Revoke permission 
 
 Revoking a permission from account sessions.

--- a/docs/specs/servers/blockchain/blockchain-permissions-api.md
+++ b/docs/specs/servers/blockchain/blockchain-permissions-api.md
@@ -9,13 +9,13 @@ Used to get account list of active sessions
 `GET /v1/sessions/{address}?projectId={projectId}`
 
 * `address` - CAIP-10 address format.
-* `projectId` - The project identifier.
+* `projectId` - Required. The project identifier.
 
 #### Success response body:
 
 ```typescript
 {
-    pci: [string]
+    pci: string[]
 }
 ```
 
@@ -33,22 +33,22 @@ Used to get permission by PCI
 
 * `address` - CAIP-10 address format.
 * `pci` - Permission identifier.
-* `projectId` - The project identifier.
+* `projectId` - Required. The project identifier.
 
 #### Success response body:
 
 ```typescript
 {
-    "type": string,
-    "data": any,
-    "required": bool,
-    "onChainValidated": bool
+    "permissionType": string,
+    "data": string,
+    "required": boolean,
+    "onChainValidated": boolean
 }
 ```
 
 #### Response error codes:
 
-* `400 Bad request` - Wrong requested address format.
+* `400 Bad request` - Wrong requested address format or PCI not found.
 
 ## Add a new permission 
 
@@ -57,7 +57,7 @@ Creating a new permission session for the account
 `POST /v1/sessions/{address}?projectId={projectId}`
 
 * `address` - CAIP-10 address format.
-* `projectId` - The project identifier.
+* `projectId` - Required. The project identifier.
 
 ### Request body:
 
@@ -65,14 +65,13 @@ The POST request body should be in JSON format and following schema:
 
 ```typescript
 {
-    permissions:[
+    permission:
         {
-          "type": string,
-          "data": any,
-          "required": bool,
-          "onChainValidated": bool
+          "permissionType": string,
+          "data": string,
+          "required": boolean,
+          "onChainValidated": boolean
         }
-    ]
 }
 ```
 
@@ -98,7 +97,7 @@ Updating permissions context for the certain permission idenitifier.
 `POST /v1/sessions/{address}/context/?projectId={projectId}`
 
 * `address` - CAIP-10 address format.
-* `projectId` - The project identifier.
+* `projectId` - Required. The project identifier.
 
 ### Request body:
 
@@ -145,7 +144,7 @@ Revoking a permission from account sessions.
 `POST /v1/sessions/{address}/revoke/?projectId={projectId}`
 
 * `address` - CAIP-10 address format.
-* `projectId` - The project identifier.
+* `projectId` - Required. The project identifier.
 
 ### Request body:
 

--- a/docs/specs/servers/blockchain/blockchain-permissions-api.md
+++ b/docs/specs/servers/blockchain/blockchain-permissions-api.md
@@ -2,7 +2,7 @@
 
 ## Sessions permissions storage
 
-### Get permissions list
+### Get permissions list for account
 
 Used to get account list of active sessions
 
@@ -15,7 +15,34 @@ Used to get account list of active sessions
 
 ```typescript
 {
-    sessions: []
+    pci: [string]
+}
+```
+
+* `pci` - List of sessions PCIs for this account.
+
+#### Response error codes:
+
+* `400 Bad request` - Wrong requested address format.
+
+### Get permission by PCI
+
+Used to get permission by PCI
+
+`GET /v1/sessions/{address}/{pci}?projectId={projectId}`
+
+* `address` - CAIP-10 address format.
+* `pci` - Permission identifier.
+* `projectId` - The project identifier.
+
+#### Success response body:
+
+```typescript
+{
+    "type": string,
+    "data": any,
+    "required": bool,
+    "onChainValidated": bool
 }
 ```
 
@@ -38,26 +65,25 @@ The POST request body should be in JSON format and following schema:
 
 ```typescript
 {
-  message: {
-    permission: {},
-    timestamp: string
-  },
-  signature: string,
+    permissions:[
+        {
+          "type": string,
+          "data": any,
+          "required": bool,
+          "onChainValidated": bool
+        }
+    ]
 }
 ```
 
-* `message` - Message that used in signature:
-    * `permission` - New permission object.
-    * `timestamp` - Current unixtime timestamp. The signature is valid for 10 seconds.
-* `signature` - Ethereum signature for the signed `message` to check the address ownership.
-
 #### Success response body:
 
-Response will contain an updated list of sessions for the address.
+Response will contain a new generated ECDSA key and PCI of the new permission.
 
 ```typescript
 {
-    sessions: []
+    key: string,
+    pci: string
 }
 ```
 
@@ -80,28 +106,17 @@ The POST request body should be in JSON format and following schema:
 
 ```typescript
 {
-  message: {
     pci: string,
-    timestamp: string
-  },
-  signature: string,
+    signature: string,
 }
 ```
 
-* `message` - Message that used in signature:
-    * `pci` - Unique permission context identifier.
-    * `timestamp` - Current unixtime timestamp. The signature is valid for 10 seconds.
-* `signature` - Ethereum signature for the signed `message` to check the address ownership.
+* `pci` - PCI to revoke.
+* `signature` - Signature signed by the key provided during the permission creation.
 
 #### Success response body:
 
-Response will contain an updated list of sessions for the address.
-
-```typescript
-{
-    sessions: []
-}
-```
+* `202 Accepted` - Successfully revoked.
 
 #### Response error codes:
 


### PR DESCRIPTION
This PR adds session permission co-signer API.

The corresponding [Notion document](https://www.notion.so/walletconnect/Permissions-Co-Signer-Minimal-Technical-Spec-366d44411ad440da96c1b9bfaacce80b).