### PR TITLE
feat(blockchainAPI): bundler interaction API

### DIFF
--- a/docs/specs/servers/blockchain/blockchain-bundler-api.md
+++ b/docs/specs/servers/blockchain/blockchain-bundler-api.md
@@ -1,0 +1,51 @@
+# Blockchain API Bundlers interaction
+
+This API provides a bundlers JSON-RPC interaction. 
+The supported `userOperation` interaction schema is according to v0.7 ERC-4337 specification.
+
+## Make a bundler JSON-RPC request
+
+Used to make a JSON-RPC call to the designated bundler.
+
+`POST /v1/bundler?projectId={projectId}&chainId={chainId}&bundler={bundlerName}`
+
+* `projectId` - Required. The project identifier.
+* `chainId` - CAIP-2 chain identifier.
+* `bundlerName` - (Optional) Bundler name to use.
+
+The list of currently supported bundler names: 
+* `pimlico` - [Pimlico bundler](https://docs.pimlico.io/permissionless/reference/bundler-actions/sendUserOperation).
+
+#### Success response body:
+
+```typescript
+{
+    id:  number, // Unique identifier. Default is 1.
+    jsonrpc: string, // JSON-RPC version. Default 2.0
+    method: string, // ERC-4337 bundler operation methods. Please check supported methods below.
+    params: string[], // Array of string variables input for the method.
+}
+```
+
+List of supported `method` values:
+* `sendUserOperation` - Sends a user operation to the given EVM network.
+* `estimateUserOperationGas` - Estimate the gas limits for a User Operation.
+* `getUserOperationByHash` - Return a User Operation based on a User Operation hash.
+* `getUserOperationReceipt` - Return a User Operation receipt based on a User Operation hash.
+* `supportedEntryPoints` - Return the Entry Points supported by the bundler.
+
+#### Success response body:
+
+Successfull response body will contain the following JSON-RPC structure:
+
+```typescript
+{
+    id: number, // Unique identifier passed to the operation. Default is 1.
+    jsonrpc: string, // JSON-RPC version. Default 2.0
+    result: object // Result object from the operation.
+}
+```
+
+#### Response error codes:
+
+* `400 Bad request` - Wrong input variables format.

--- a/docs/specs/servers/blockchain/blockchain-bundler-api.md
+++ b/docs/specs/servers/blockchain/blockchain-bundler-api.md
@@ -40,7 +40,7 @@ Successfull response body will contain the following JSON-RPC structure:
 {
     id: number, // Unique identifier passed to the operation. Default is 1.
     jsonrpc: string, // JSON-RPC version. Default 2.0
-    result: object // Result object from the operation.
+    result: any // Result object from the operation.
 }
 ```
 

--- a/docs/specs/servers/blockchain/blockchain-bundler-api.md
+++ b/docs/specs/servers/blockchain/blockchain-bundler-api.md
@@ -30,6 +30,7 @@ The list of currently supported bundler names:
 List of supported `method` values:
 * `wallet_getCallsStatus` - Returns the status of a call batch that was sent via `wallet_sendCalls`.
 * `wallet_showCallsStatus` - Requests that a wallet shows information about a given call bundle that was sent with `wallet_sendCalls`.
+* `eth_getUserOperationReceipt` - Get the receipt for the UserOperation.
 
 #### Success response body:
 

--- a/docs/specs/servers/blockchain/blockchain-bundler-api.md
+++ b/docs/specs/servers/blockchain/blockchain-bundler-api.md
@@ -28,11 +28,8 @@ The list of currently supported bundler names:
 ```
 
 List of supported `method` values:
-* `sendUserOperation` - Sends a user operation to the given EVM network.
-* `estimateUserOperationGas` - Estimate the gas limits for a User Operation.
-* `getUserOperationByHash` - Return a User Operation based on a User Operation hash.
-* `getUserOperationReceipt` - Return a User Operation receipt based on a User Operation hash.
-* `supportedEntryPoints` - Return the Entry Points supported by the bundler.
+* `wallet_getCallsStatus` - Returns the status of a call batch that was sent via `wallet_sendCalls`.
+* `wallet_showCallsStatus` - Requests that a wallet shows information about a given call bundle that was sent with `wallet_sendCalls`.
 
 #### Success response body:
 

--- a/docs/specs/servers/blockchain/blockchain-bundler-api.md
+++ b/docs/specs/servers/blockchain/blockchain-bundler-api.md
@@ -11,7 +11,7 @@ Used to make a JSON-RPC call to the designated bundler.
 
 * `projectId` - Required. The project identifier.
 * `chainId` - CAIP-2 chain identifier.
-* `bundlerName` - (Optional) Bundler name to use.
+* `bundlerName` - Bundler name to use.
 
 The list of currently supported bundler names: 
 * `pimlico` - [Pimlico bundler](https://docs.pimlico.io/permissionless/reference/bundler-actions/sendUserOperation).

--- a/docs/specs/servers/blockchain/blockchain-bundler-api.md
+++ b/docs/specs/servers/blockchain/blockchain-bundler-api.md
@@ -16,7 +16,7 @@ Used to make a JSON-RPC call to the designated bundler.
 The list of currently supported bundler names: 
 * `pimlico` - [Pimlico bundler](https://docs.pimlico.io/permissionless/reference/bundler-actions/sendUserOperation).
 
-#### Success response body:
+#### Request body:
 
 ```typescript
 {


### PR DESCRIPTION
This PR adds a bundler interaction API to the Blockchain-API new `/v1/bundler` endpoint. The user can choose the bundler to call and pass the json-rpc operation to the designated bundler.