### PR TITLE
feat(blockchainAPI): adding `v=2` optional query parameter for name lookups

### DIFF
--- a/docs/specs/servers/blockchain/blockchain-api.md
+++ b/docs/specs/servers/blockchain/blockchain-api.md
@@ -45,6 +45,10 @@ Used to lookup address for the name.
     * Case insensitive alphabetic characters (a-z), numeric characters (0-9), the minus sign (-) and the period (.).
     * Max 255 characters length.
 
+#### Query parameters:
+
+* `v` - (Optional) API version specification. `1` by default. Can be `2` to force using the updated API response.
+
 #### Success response body:
 
 ```typescript
@@ -68,10 +72,15 @@ Used to lookup address for the name.
     * `avatar` - (Optional) avatar url.
     * `bio` - (Optional) account profile self description.
 
+#### Name was not found response:
+
+By default, or using `v=1` query parameter the response will be `HTTP 404`.
+When using `v=2` query parameter the response will be an empty array `[]`.
+
 #### Response error codes:
 
 * `400 Bad request` - Wrong requested name format.
-* `404 Not Found` - The requested name is not registered.
+* `404 Not Found` - Default or when using `v=1` query parameter: the requested name is not registered.
 
 ### Reverse name lookup
 
@@ -87,6 +96,10 @@ Or the lookup for account name by the address in a specified chain:
 
 * `coin_type` - [ENSIP-11](https://alpha-docs.ens.domains/ensip/11) coin type for the registered address and name.
 * `address` - Ihe address for lookup. eg. `0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb`
+
+#### Query parameters:
+
+* `v` - (Optional) API version specification. `1` by default. Can be `2` to force using the updated API response.
 
 #### Success response body:
 
@@ -111,10 +124,15 @@ Or the lookup for account name by the address in a specified chain:
     * `avatar` - (Optional) avatar url.
     * `bio` - (Optional) account profile self description.
 
+#### Name was not found response:
+
+By default, or using `v=1` query parameter the response will be `HTTP 404`.
+When using `v=2` query parameter the response will be an empty array `[]`.
+
 #### Response error codes:
 
 * `400 Bad Request` - Wrong requested address format.
-* `404 Not Found` - The requested address is not registered for any name or for the specified chain.
+* `404 Not Found` - Default or when using `v=1` query parameter: the requested address is not registered for any name or for the specified chain.
 
 ### Name suggestion
 

--- a/docs/specs/servers/blockchain/blockchain-api.md
+++ b/docs/specs/servers/blockchain/blockchain-api.md
@@ -74,13 +74,13 @@ Used to lookup address for the name.
 
 #### Name was not found response:
 
-By default, or using `v=1` query parameter the response will be `HTTP 404`.
-When using `v=2` query parameter the response will be an empty array `[]`.
+By default, or using `apiVersion=1` query parameter the response will be `HTTP 404`.
+When using `apiVersion=2` query parameter the response will be an empty array `[]`.
 
 #### Response error codes:
 
 * `400 Bad request` - Wrong requested name format.
-* `404 Not Found` - Default or when using `v=1` query parameter: the requested name is not registered.
+* `404 Not Found` - Default or when using `apiVersion=1` query parameter: the requested name is not registered.
 
 ### Reverse name lookup
 
@@ -126,13 +126,13 @@ Or the lookup for account name by the address in a specified chain:
 
 #### Name was not found response:
 
-By default, or using `v=1` query parameter the response will be `HTTP 404`.
-When using `v=2` query parameter the response will be an empty array `[]`.
+By default, or using `apiVersion=1` query parameter the response will be `HTTP 404`.
+When using `apiVersion=2` query parameter the response will be an empty array `[]`.
 
 #### Response error codes:
 
 * `400 Bad Request` - Wrong requested address format.
-* `404 Not Found` - Default or when using `v=1` query parameter: the requested address is not registered for any name or for the specified chain.
+* `404 Not Found` - Default or when using `apiVersion=1` query parameter: the requested address is not registered for any name or for the specified chain.
 
 ### Name suggestion
 

--- a/docs/specs/servers/blockchain/blockchain-api.md
+++ b/docs/specs/servers/blockchain/blockchain-api.md
@@ -47,7 +47,7 @@ Used to lookup address for the name.
 
 #### Query parameters:
 
-* `v` - (Optional) API version specification. `1` by default. Can be `2` to force using the updated API response.
+* `apiVersion` - (Optional) API version specification. `1` by default. Can be `2` to force using the updated API response.
 
 #### Success response body:
 
@@ -99,7 +99,7 @@ Or the lookup for account name by the address in a specified chain:
 
 #### Query parameters:
 
-* `v` - (Optional) API version specification. `1` by default. Can be `2` to force using the updated API response.
+* `apiVersion` - (Optional) API version specification. `1` by default. Can be `2` to force using the updated API response.
 
 #### Success response body:
 


### PR DESCRIPTION
This PR adds an optional `apiVersion=2` query parameter for name lookups to fix the [404 response issue](https://github.com/WalletConnect/blockchain-api/issues/700) and support backward compatibility.