### PR TITLE
feat(blockchainAPI): adding optional zone query parameter for the name suggestions

### DIFF
--- a/docs/specs/servers/blockchain/blockchain-api.md
+++ b/docs/specs/servers/blockchain/blockchain-api.md
@@ -144,6 +144,11 @@ Used to lookup for suggestions for the new name by returning 3 unique usernames.
 
 * `name` - The preffered name. Minimum 3 characters length.
 
+
+#### Query parameters:
+
+* `zone` - (Optional) Name zone for suggestions.
+
 #### Success response body:
 
 ```jsonc


### PR DESCRIPTION
This PR adds an optional `zone` query parameter to the name suggestion endpoint to support a backward compatibility for the legacy `wcn.id` name. By default the `wcn.id` name zone will be used for the backward compatibility and `zone=x` should be used for the new domain zone.