### PR TITLE
fix(blockchainApi): fixing the balance filtering parameter by chainId

### DIFF
--- a/docs/specs/servers/blockchain/blockchain-api.md
+++ b/docs/specs/servers/blockchain/blockchain-api.md
@@ -360,7 +360,7 @@ Otherwise the response will be an empty array.
 * `projectId` - The project identifier.
 * `currency` - Currency to calculate the assets value. e.g. `usd`.
     * Supported currencies: `btc`, `eth`, `usd`, `eur`, `gbp`, `aud`, `cad`, `inr`, `jpy`.
-* `chain` - (Optional) Filter assets by CAIP-2 chain id. Supported chain IDs:
+* `chainId` - (Optional) Filter assets by CAIP-2 chain id. Supported chain IDs:
     * `eip155:1` - Ethereum
     * `eip155:5` - Goerli
     * `eip155:56` - BinanceSmartChain
@@ -378,7 +378,7 @@ Otherwise the response will be an empty array.
     * `eip155:8508132` - Scroll
     * `eip155:7854577` - Zora
     * `eip155:1313161554` - Aurora
-* `forceUpdate` - (Optional) List of comma separated token contract addresses (CAIP-10 format) to force the latest balance update on. `chain` must be also provided for this type of call.
+* `forceUpdate` - (Optional) List of comma separated token contract addresses (CAIP-10 format) to force the latest balance update on. `chainId` must be also provided for this type of call.
 
 #### Success response body:
 


### PR DESCRIPTION
This PR fixes the Blockchain-API balances filtering parameter name from `chain` to `chainId`.