### PR TITLE
fix(blockchainAPI): adding `decimals` to the fungible price endpoint

### DIFF
--- a/docs/specs/servers/blockchain/blockchain-api.md
+++ b/docs/specs/servers/blockchain/blockchain-api.md
@@ -485,6 +485,7 @@ The POST request body should be in JSON format with the folowing structure:
     * `symbol` - Native asset or ERC-20 symbol. e.g. `ETH`.
     * `iconUrl` - URL of the asset icon.
     * `price` - Price of a single unit of the asset in currency calculated from the request argument.
+    * `decimals` - Asset decimals.
 
 #### Response error codes:
 


### PR DESCRIPTION
This PR adds `decimals` field description to the `/v1/fungible/price` endpoint response.